### PR TITLE
Move Tailscale from self-hosting to VPN section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1033,6 +1033,26 @@
       </details>
       <div class="tg-foot"><a class="tg-link" href="https://www.ivpn.net" target="_blank" rel="noopener">ivpn.net →</a><span class="tg-note">🟡🔴</span></div>
     </article>
+
+    <article class="tg" id="t-tailscale">
+      <div class="tg-h">
+        <span class="tg-logo" style="--b:#242424">Ts</span>
+        <div class="tg-hd"><h3 class="tg-name">Tailscale · Headscale · WireGuard</h3>
+          <div class="tg-tags"><span class="tg-tag">🔴 <span data-l="fr">Avancé</span><span data-l="en">Advanced</span><span data-l="nl">Expert</span></span><span class="tg-tag"><span data-l="fr">Accès privé à son serveur</span><span data-l="en">Private access to your server</span><span data-l="nl">Privétoegang tot uw server</span></span><span class="tg-tag">🌍 · open-source</span></div>
+        </div>
+      </div>
+      <p class="tg-field"><b class="lbl lbl-what"></b><span data-l="fr">Un réseau privé chiffré qui relie vos appareils à votre serveur, sans jamais l'exposer sur l'Internet public.</span><span data-l="en">A private encrypted network linking your devices to your server, without ever exposing it on the public internet.</span><span data-l="nl">Een privé versleuteld netwerk dat uw apparaten aan uw server koppelt, zonder deze ooit bloot te stellen aan het publieke internet.</span></p>
+      <p class="tg-field"><b class="lbl lbl-why"></b><span data-l="fr">Au lieu d'ouvrir des ports (et de vous faire attaquer), <b>Tailscale</b> crée un tunnel WireGuard entre vos seuls appareils autorisés : votre serveur n'a aucune surface d'attaque publique. <b>Headscale</b> est la version que vous hébergez vous-même, pour ne dépendre d'aucun tiers. <b>WireGuard</b> seul offre le contrôle total, au prix d'une configuration manuelle.</span><span data-l="en">Instead of opening ports (and getting attacked), <b>Tailscale</b> builds a WireGuard tunnel between your authorised devices only: your server has no public attack surface. <b>Headscale</b> is the self-hosted version, so you depend on no third party. <b>WireGuard</b> alone gives full control, at the cost of manual setup.</span><span data-l="nl">In plaats van poorten te openen (en aangevallen te worden), bouwt <b>Tailscale</b> een WireGuard-tunnel tussen alleen uw geautoriseerde apparaten: uw server heeft geen publiek aanvalsoppervlak. <b>Headscale</b> is de zelf-gehoste versie, zodat u van geen enkele derde partij afhankelijk bent. <b>WireGuard</b> alleen biedt volledige controle, ten koste van handmatige configuratie.</span></p>
+      <p class="tg-field"><b class="lbl lbl-who"></b><span data-l="fr">Tout auto-hébergeur. C'est la façon sûre d'atteindre son Nextcloud ou ses photos depuis l'extérieur.</span><span data-l="en">Every self-hoster. It's the safe way to reach your Nextcloud or photos from outside.</span><span data-l="nl">Elke zelf-hoster. Het is de veilige manier om van buitenaf uw Nextcloud of foto's te bereiken.</span></p>
+      <details class="tg-install"><summary></summary>
+        <ol class="tg-steps">
+          <li><span data-l="fr">Installez Tailscale sur votre serveur et sur votre téléphone/PC, connectez-les au même compte.</span><span data-l="en">Install Tailscale on your server and on your phone/PC, connect them to the same account.</span><span data-l="nl">Installeer Tailscale op uw server en op uw telefoon/pc, en koppel ze aan hetzelfde account.</span></li>
+          <li><span data-l="fr">Vos appareils se voient aussitôt sur un réseau privé ; accédez à votre serveur par son adresse Tailscale.</span><span data-l="en">Your devices instantly see each other on a private network; reach your server at its Tailscale address.</span><span data-l="nl">Uw apparaten zien elkaar meteen op een privénetwerk; bereik uw server via het Tailscale-adres.</span></li>
+          <li><span data-l="fr">Pour zéro dépendance, remplacez le serveur de coordination par Headscale, auto-hébergé.</span><span data-l="en">For zero dependency, replace the coordination server with self-hosted Headscale.</span><span data-l="nl">Voor nul afhankelijkheid vervangt u de coördinatieserver door zelf-gehoste Headscale.</span></li>
+        </ol>
+      </details>
+      <div class="tg-foot"><a class="tg-link" href="https://tailscale.com" target="_blank" rel="noopener">tailscale.com →</a><a class="tg-link" href="https://headscale.net" target="_blank" rel="noopener">headscale.net →</a><span class="tg-note">🔴</span></div>
+    </article>
   </section>
 
   <!-- ============ CENSORSHIP / ID VERIFICATION ============ -->
@@ -1613,7 +1633,7 @@
           <li><span data-l="fr">Récupérez un vieil ordinateur, un Raspberry Pi, ou louez un petit serveur (VPS) dans un pays protecteur.</span><span data-l="en">Get an old computer, a Raspberry Pi, or rent a small server (VPS) in a protective country.</span><span data-l="nl">Pak een oude computer, een Raspberry Pi, of huur een kleine server (VPS) in een beschermend land.</span></li>
           <li><span data-l="fr">Installez YunoHost, Umbrel ou Start9 en suivant leur guide officiel.</span><span data-l="en">Install YunoHost, Umbrel or Start9 following their official guide.</span><span data-l="nl">Installeer YunoHost, Umbrel of Start9 volgens hun officiële handleiding.</span></li>
           <li><span data-l="fr">Depuis le catalogue, installez Nextcloud, un serveur Matrix, une galerie photo, etc.</span><span data-l="en">From the catalogue, install Nextcloud, a Matrix server, a photo gallery, etc.</span><span data-l="nl">Installeer vanuit de catalogus Nextcloud, een Matrix-server, een fotogalerij, enz.</span></li>
-          <li><span data-l="fr">Accédez-y en privé avec Tailscale (fiche ci-dessous) plutôt que d'exposer le serveur au public.</span><span data-l="en">Reach it privately with Tailscale (card below) rather than exposing the server to the public.</span><span data-l="nl">Bereik het privé met Tailscale (kaart hieronder) in plaats van de server bloot te stellen aan het publieke internet.</span></li>
+          <li><span data-l="fr">Accédez-y en privé avec Tailscale (section VPN) plutôt que d'exposer le serveur au public.</span><span data-l="en">Reach it privately with Tailscale (VPN section) rather than exposing the server to the public.</span><span data-l="nl">Bereik het privé met Tailscale (VPN-sectie) in plaats van de server bloot te stellen aan het publieke internet.</span></li>
         </ol>
       </details>
       <div class="tg-foot"><a class="tg-link" href="https://yunohost.org" target="_blank" rel="noopener">yunohost.org →</a><a class="tg-link" href="https://umbrel.com" target="_blank" rel="noopener">umbrel.com →</a><a class="tg-link" href="https://start9.com" target="_blank" rel="noopener">start9.com →</a><span class="tg-note">🔴</span></div>
@@ -1643,26 +1663,6 @@
       <p class="tg-field"><b class="lbl lbl-why"></b><span data-l="fr">En hébergeant le serveur, vous contrôlez aussi les <b>métadonnées</b> (qui parle à qui, quand), le point faible de Matrix en fédération. C'est la messagerie communautaire dont vous êtes le seul maître.</span><span data-l="en">By hosting the server, you also control the <b>metadata</b> (who talks to whom, when), Matrix's weak point in federation. It's community chat that you alone own.</span><span data-l="nl">Door de server te hosten, beheert u ook de <b>metadata</b> (wie met wie praat, wanneer), het zwakke punt van Matrix in federatie. Het is communitychat waarvan u alleen de eigenaar bent.</span></p>
       <p class="tg-field"><b class="lbl lbl-who"></b><span data-l="fr">Communautés, collectifs, rédactions qui veulent leur espace fédéré indépendant.</span><span data-l="en">Communities, collectives, newsrooms that want their own independent federated space.</span><span data-l="nl">Gemeenschappen, collectieven, redacties die hun eigen onafhankelijke gefedereerde ruimte willen.</span></p>
       <div class="tg-foot"><a class="tg-link" href="https://element.io/server" target="_blank" rel="noopener">element.io/server →</a><span class="tg-note">🔴</span></div>
-    </article>
-
-    <article class="tg" id="t-tailscale">
-      <div class="tg-h">
-        <span class="tg-logo" style="--b:#242424">Ts</span>
-        <div class="tg-hd"><h3 class="tg-name">Tailscale · Headscale · WireGuard</h3>
-          <div class="tg-tags"><span class="tg-tag">🔴 <span data-l="fr">Avancé</span><span data-l="en">Advanced</span><span data-l="nl">Expert</span></span><span class="tg-tag"><span data-l="fr">Accès privé à son serveur</span><span data-l="en">Private access to your server</span><span data-l="nl">Privétoegang tot uw server</span></span><span class="tg-tag">🌍 · open-source</span></div>
-        </div>
-      </div>
-      <p class="tg-field"><b class="lbl lbl-what"></b><span data-l="fr">Un réseau privé chiffré qui relie vos appareils à votre serveur, sans jamais l'exposer sur l'Internet public.</span><span data-l="en">A private encrypted network linking your devices to your server, without ever exposing it on the public internet.</span><span data-l="nl">Een privé versleuteld netwerk dat uw apparaten aan uw server koppelt, zonder deze ooit bloot te stellen aan het publieke internet.</span></p>
-      <p class="tg-field"><b class="lbl lbl-why"></b><span data-l="fr">Au lieu d'ouvrir des ports (et de vous faire attaquer), <b>Tailscale</b> crée un tunnel WireGuard entre vos seuls appareils autorisés : votre serveur n'a aucune surface d'attaque publique. <b>Headscale</b> est la version que vous hébergez vous-même, pour ne dépendre d'aucun tiers. <b>WireGuard</b> seul offre le contrôle total, au prix d'une configuration manuelle.</span><span data-l="en">Instead of opening ports (and getting attacked), <b>Tailscale</b> builds a WireGuard tunnel between your authorised devices only: your server has no public attack surface. <b>Headscale</b> is the self-hosted version, so you depend on no third party. <b>WireGuard</b> alone gives full control, at the cost of manual setup.</span><span data-l="nl">In plaats van poorten te openen (en aangevallen te worden), bouwt <b>Tailscale</b> een WireGuard-tunnel tussen alleen uw geautoriseerde apparaten: uw server heeft geen publiek aanvalsoppervlak. <b>Headscale</b> is de zelf-gehoste versie, zodat u van geen enkele derde partij afhankelijk bent. <b>WireGuard</b> alleen biedt volledige controle, ten koste van handmatige configuratie.</span></p>
-      <p class="tg-field"><b class="lbl lbl-who"></b><span data-l="fr">Tout auto-hébergeur. C'est la façon sûre d'atteindre son Nextcloud ou ses photos depuis l'extérieur.</span><span data-l="en">Every self-hoster. It's the safe way to reach your Nextcloud or photos from outside.</span><span data-l="nl">Elke zelf-hoster. Het is de veilige manier om van buitenaf uw Nextcloud of foto's te bereiken.</span></p>
-      <details class="tg-install"><summary></summary>
-        <ol class="tg-steps">
-          <li><span data-l="fr">Installez Tailscale sur votre serveur et sur votre téléphone/PC, connectez-les au même compte.</span><span data-l="en">Install Tailscale on your server and on your phone/PC, connect them to the same account.</span><span data-l="nl">Installeer Tailscale op uw server en op uw telefoon/pc, en koppel ze aan hetzelfde account.</span></li>
-          <li><span data-l="fr">Vos appareils se voient aussitôt sur un réseau privé ; accédez à votre serveur par son adresse Tailscale.</span><span data-l="en">Your devices instantly see each other on a private network; reach your server at its Tailscale address.</span><span data-l="nl">Uw apparaten zien elkaar meteen op een privénetwerk; bereik uw server via het Tailscale-adres.</span></li>
-          <li><span data-l="fr">Pour zéro dépendance, remplacez le serveur de coordination par Headscale, auto-hébergé.</span><span data-l="en">For zero dependency, replace the coordination server with self-hosted Headscale.</span><span data-l="nl">Voor nul afhankelijkheid vervangt u de coördinatieserver door zelf-gehoste Headscale.</span></li>
-        </ol>
-      </details>
-      <div class="tg-foot"><a class="tg-link" href="https://tailscale.com" target="_blank" rel="noopener">tailscale.com →</a><a class="tg-link" href="https://headscale.net" target="_blank" rel="noopener">headscale.net →</a><span class="tg-note">🔴</span></div>
     </article>
 
     <article class="tg" id="t-website">


### PR DESCRIPTION
Move the Tailscale/Headscale/WireGuard tool card from the self-hosting section (Part 10) to the VPN section (Part 04), after IVPN.

Rationale: Tailscale is primarily a VPN/mesh networking tool, not a self-hosting service. It fits better alongside Mullvad, ProtonVPN and IVPN in the VPN section.

Also updates the cross-reference in YunoHost install steps from 'card below' to 'VPN section'.