### PR TITLE
feat(content): add Pocketpal in the AI section

### DIFF
--- a/src/content/sections/en/15-ia.mdx
+++ b/src/content/sections/en/15-ia.mdx
@@ -60,6 +60,34 @@ What you type into a cloud AI is a **written, timestamped, stored confession**. 
   </ol>
 </ToolCard>
 
+<ToolCard tool="t-pocketpal">
+  <Fragment slot="tags">
+    <span class="tool-tag">🟡🔴</span>
+    <span class="tool-tag">Replaces ChatGPT on mobile</span>
+    <span class="tool-tag">📱 · 100% local</span>
+  </Fragment>
+  <Fragment slot="what">An app that runs AI models directly on your phone, fully offline.</Fragment>
+  <Fragment slot="why">
+    Your prompts never leave the phone: no account, no cloud, no telemetry, and it works in airplane
+    mode. Open source (MIT), it downloads <b>GGUF</b> models (Gemma, Qwen, Phi, Llama) from Hugging
+    Face and runs them on your device's CPU, GPU or NPU. The mobile counterpart to Ollama and LM
+    Studio.
+  </Fragment>
+  <Fragment slot="who">
+    Anyone who reaches for ChatGPT on their phone for personal questions and doesn't want to hand
+    them to a US server.
+  </Fragment>
+  <ol slot="install">
+    <li>
+      Install <b>PocketPal</b> from the App Store or Google Play (or build it from source).
+    </li>
+    <li>
+      Open <b>Models</b>, pick one that fits your phone, and download it.
+    </li>
+    <li>Load it and chat: everything runs offline, on the device.</li>
+  </ol>
+</ToolCard>
+
 <ToolCard tool="t-cloudai">
   <Fragment slot="tags">
     <span class="tool-tag">🟢🟡</span>

--- a/src/content/sections/fr/15-ia.mdx
+++ b/src/content/sections/fr/15-ia.mdx
@@ -65,6 +65,37 @@ Ce que vous tapez dans une IA cloud est une **confession écrite, horodatée et 
   </ol>
 </ToolCard>
 
+<ToolCard tool="t-pocketpal">
+  <Fragment slot="tags">
+    <span class="tool-tag">🟡🔴</span>
+    <span class="tool-tag">Remplace ChatGPT sur mobile</span>
+    <span class="tool-tag">📱 · 100% local</span>
+  </Fragment>
+  <Fragment slot="what">
+    Une application pour faire tourner des modèles d'IA directement sur votre téléphone, entièrement
+    hors ligne.
+  </Fragment>
+  <Fragment slot="why">
+    Vos requêtes ne quittent jamais le téléphone : aucun compte, aucun cloud, aucune télémétrie, et
+    ça marche en mode avion. Open source (MIT), l'appli télécharge des modèles <b>GGUF</b> (Gemma,
+    Qwen, Phi, Llama) depuis Hugging Face et les exécute sur le CPU, le GPU ou le NPU de l'appareil.
+    Le pendant mobile d'Ollama et LM Studio.
+  </Fragment>
+  <Fragment slot="who">
+    Tous ceux qui dégainent ChatGPT sur leur téléphone pour des questions personnelles et ne veulent
+    pas les confier à un serveur américain.
+  </Fragment>
+  <ol slot="install">
+    <li>
+      Installez <b>PocketPal</b> depuis l'App Store ou Google Play (ou compilez les sources).
+    </li>
+    <li>
+      Ouvrez <b>Models</b>, choisissez un modèle adapté à votre téléphone et téléchargez-le.
+    </li>
+    <li>Chargez-le et discutez : tout tourne hors ligne, sur l'appareil.</li>
+  </ol>
+</ToolCard>
+
 <ToolCard tool="t-cloudai">
   <Fragment slot="tags">
     <span class="tool-tag">🟢🟡</span>

--- a/src/content/sections/nl/15-ia.mdx
+++ b/src/content/sections/nl/15-ia.mdx
@@ -62,6 +62,36 @@ Wat u in een cloud-AI typt, is een **geschreven, van een tijdstempel voorziene, 
   </ol>
 </ToolCard>
 
+<ToolCard tool="t-pocketpal">
+  <Fragment slot="tags">
+    <span class="tool-tag">🟡🔴</span>
+    <span class="tool-tag">Vervangt ChatGPT op mobiel</span>
+    <span class="tool-tag">📱 · 100% lokaal</span>
+  </Fragment>
+  <Fragment slot="what">
+    Een app om AI-modellen rechtstreeks op uw telefoon te draaien, volledig offline.
+  </Fragment>
+  <Fragment slot="why">
+    Uw prompts verlaten de telefoon nooit: geen account, geen cloud, geen telemetrie, en het werkt
+    in vliegtuigmodus. Open source (MIT): de app downloadt <b>GGUF</b>-modellen (Gemma, Qwen, Phi,
+    Llama) van Hugging Face en draait ze op de CPU, GPU of NPU van het toestel. De mobiele
+    tegenhanger van Ollama en LM Studio.
+  </Fragment>
+  <Fragment slot="who">
+    Iedereen die op de telefoon naar ChatGPT grijpt voor persoonlijke vragen en ze niet aan een
+    Amerikaanse server wil toevertrouwen.
+  </Fragment>
+  <ol slot="install">
+    <li>
+      Installeer <b>PocketPal</b> uit de App Store of Google Play (of bouw vanaf de broncode).
+    </li>
+    <li>
+      Open <b>Models</b>, kies een model dat bij uw telefoon past en download het.
+    </li>
+    <li>Laad het en chat: alles draait offline, op het toestel.</li>
+  </ol>
+</ToolCard>
+
 <ToolCard tool="t-cloudai">
   <Fragment slot="tags">
     <span class="tool-tag">🟢🟡</span>

--- a/src/data/directory.json
+++ b/src/data/directory.json
@@ -398,6 +398,13 @@
     "license": "MIT"
   },
   {
+    "id": "pocketpal",
+    "category": "ia-locale-agentique",
+    "name": "PocketPal AI",
+    "url": "https://pocketpal.dev",
+    "license": "MIT"
+  },
+  {
     "id": "grapheneos",
     "category": "os-mobile",
     "name": "GrapheneOS",

--- a/src/data/domains-allowlist.json
+++ b/src/data/domains-allowlist.json
@@ -78,6 +78,7 @@
     "osmand.net",
     "pi-hole.net",
     "pixelfed.org",
+    "pocketpal.dev",
     "posteo.de",
     "postmarketos.org",
     "proton.me",

--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -620,6 +620,25 @@
     "profiles": ["🟡", "🔴"]
   },
   {
+    "id": "t-pocketpal",
+    "name": "PocketPal AI",
+    "url": "https://pocketpal.dev",
+    "links": [
+      {
+        "label": "pocketpal.dev",
+        "href": "https://pocketpal.dev"
+      },
+      {
+        "label": "github",
+        "href": "https://github.com/a-ghorbani/pocketpal-ai"
+      }
+    ],
+    "monogram": "Pp",
+    "color": "#6b4eff",
+    "level": null,
+    "profiles": ["🟡", "🔴"]
+  },
+  {
     "id": "t-cloudai",
     "name": "Duck.ai · Lumo (Proton)",
     "url": "https://duck.ai",

--- a/src/i18n/content/en/directory.json
+++ b/src/i18n/content/en/directory.json
@@ -50,6 +50,7 @@
   "llama-cpp": { "body": "The local inference engine that made it all possible." },
   "jan": { "body": "100% local ChatGPT-like, simple UI." },
   "gpt4all": { "body": "Privacy-minded local LLMs, CPU-friendly." },
+  "pocketpal": { "body": "Run LLMs offline on your phone (iOS/Android), no account." },
   "grapheneos": { "body": "De-Googled, hardened Android (Pixel)." },
   "tails": { "body": "Amnesic USB OS, everything through Tor." },
   "qubes-os": { "body": "Compartmentalisation via sealed VMs." },

--- a/src/i18n/content/fr/directory.json
+++ b/src/i18n/content/fr/directory.json
@@ -52,6 +52,7 @@
   "llama-cpp": { "body": "Le moteur d’inférence local qui a tout rendu possible." },
   "jan": { "body": "ChatGPT-like 100 % local, interface simple." },
   "gpt4all": { "body": "LLM locaux orientés vie privée, sur CPU." },
+  "pocketpal": { "body": "Des LLM hors ligne sur votre téléphone (iOS/Android), sans compte." },
   "grapheneos": { "body": "Android dégooglisé et durci (Pixel)." },
   "tails": { "body": "OS amnésique sur clé USB, tout via Tor." },
   "qubes-os": { "body": "Cloisonnement par machines virtuelles étanches." },

--- a/src/i18n/content/nl/directory.json
+++ b/src/i18n/content/nl/directory.json
@@ -153,6 +153,9 @@
   "gpt4all": {
     "body": "Privacygerichte lokale LLM's, CPU-vriendelijk."
   },
+  "pocketpal": {
+    "body": "Draai LLM's offline op je telefoon (iOS/Android), zonder account."
+  },
   "grapheneos": {
     "body": "Ontgoogeld, gehard Android (Pixel)."
   },

--- a/src/styles/brands.generated.css
+++ b/src/styles/brands.generated.css
@@ -146,6 +146,10 @@
   background: #111111;
   color: #faf7ee;
 }
+#t-pocketpal .tool-logo {
+  background: #6b4eff;
+  color: #faf7ee;
+}
 #t-cloudai .tool-logo {
   background: #de5833;
   color: #14161a;

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -133,8 +133,8 @@ describe('open-source directory', () => {
   ])
   const directory = loadDataset('directory', 'en')
 
-  it('has 66 entries: free-software license allowlist, https links', () => {
-    expect(directory).toHaveLength(66)
+  it('has 67 entries: free-software license allowlist, https links', () => {
+    expect(directory).toHaveLength(67)
     for (const e of directory) {
       expect(SPDX_ALLOWED.has(e.license), `${e.name}: license ${e.license}`).toBe(true)
       expect(e.url.startsWith('https://'), e.name).toBe(true)


### PR DESCRIPTION
# Add PocketPal AI to the Conversational AI section

## Summary

Adds **PocketPal AI**, a private, on-device LLM app for iOS/Android, to the "Conversational AI" blind-spot section (Part 14) and to the open-source directory. It fills a real gap: the section currently covers _desktop_ local AI (Ollama, LM Studio, Jan, GPT4All), while PocketPal is the **mobile** counterpart, local AI on the one device most people actually type their private questions into.

## Why it qualifies (the three rules)

1. **Traction**: 7.5k★ / 767 forks, 80 releases (latest `v1.16.1`, Jul 2026), shipping on both the App Store and Google Play. Actively maintained, real user base.
2. **Open source**: MIT licensed, public repo at <https://github.com/a-ghorbani/pocketpal-ai>.
3. **Privacy-respecting**: runs models fully on-device, offline, with no account and no cloud. Per the project's own privacy note, the only data that ever leaves the device is what the user explicitly opts into (benchmark leaderboard submission, in-app feedback). No trackers, no data monetization.

Sources: project site <https://pocketpal.dev> and repo/README <https://github.com/a-ghorbani/pocketpal-ai>.

## Affiliation disclosure

I am **not** affiliated with PocketPal AI or its maintainer in any way (not author, employee, investor, or contributor). _(Please edit this line before submitting if that is not accurate for you.)_

## What changed

- `src/data/tools.json`: new `t-pocketpal` tool (name, `pocketpal.dev` + GitHub links, monogram tile; no simple-icons glyph exists, so it uses a letter monogram like Briar/llama.cpp).
- `src/content/sections/{en,fr,nl}/15-ia.mdx`: a `<ToolCard>` placed between the desktop local-AI card and the privacy-cloud card, in all three languages.
- `src/data/directory.json`: a `pocketpal` entry in the existing `ia-locale-agentique` category (MIT, https).
- `src/i18n/content/{en,fr,nl}/directory.json`: the one-line localized role for the directory entry (NL machine-translated, matching the existing stamp).
- `src/data/domains-allowlist.json`: adds `pocketpal.dev` (the only new external domain; `github.com` was already allowlisted).
- `tests/unit/content.test.ts`: directory count bumped 66 to 67.
- `src/styles/brands.generated.css`: regenerated via `pnpm icons` (adds the tile rule for the new tool).

## Link & editorial policy

- All new external links go through the existing `Ext`/ToolCard rendering, so `rel="noopener noreferrer"` is enforced; no per-link `rel` overrides.
- The only allowlist addition is `pocketpal.dev`, kept as an explicit, reviewable one-line diff.
- No editorial elevation: PocketPal is added as an equal card and an equal directory row, nothing is featured, reordered, or ranked. Placement is left to the maintainer's discretion.

## i18n parity

EN/FR/NL are all updated (section card + directory role); overlay parity and the NL machine-translation stamp are preserved.

## Testing

`pnpm lint && pnpm check && pnpm build && pnpm test` all pass locally (34 unit tests green, incl. domain-allowlist audit of `dist/`, i18n parity, and content integrity). Site remains static, no third-party requests, no inline styles.
