### PR TITLE
content(menace): restaure les deux lignes différées du tableau (Durée · Statut) avec la chaîne vérifiée

### DIFF
--- a/src/content/sections/en/01-menace.mdx
+++ b/src/content/sections/en/01-menace.mdx
@@ -47,6 +47,22 @@ Before you change tools, understand what you are protecting against. Otherwise y
           <strong>All</strong> platforms, including end-to-end encrypted messengers
         </td>
       </tr>
+      <tr>
+        <td>Duration</td>
+        <td>
+          Temporary — <strong>lapsed on 3 April 2026</strong>, reinstated on 9 July 2026 until 3
+          April 2028
+        </td>
+        <td>Permanent (the Council position deletes the sunset clause)</td>
+      </tr>
+      <tr>
+        <td>Status (Jul 2026)</td>
+        <td>
+          Reinstated on 9 July 2026 at second reading — the rejection motion fails (314 in favour,
+          361 needed), an amendment carves out end-to-end encryption
+        </td>
+        <td>Under negotiation — 5th trilogue failed on 29 June</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/src/content/sections/fr/01-menace.mdx
+++ b/src/content/sections/fr/01-menace.mdx
@@ -48,6 +48,22 @@ Avant de changer d'outils, il faut comprendre ce contre quoi on se protège. Sin
           bout
         </td>
       </tr>
+      <tr>
+        <td>Durée</td>
+        <td>
+          Temporaire — <strong>expiré le 3 avril 2026</strong>, rétabli le 9 juillet 2026 jusqu'au 3
+          avril 2028
+        </td>
+        <td>Permanent (la position du Conseil supprime la clause d'extinction)</td>
+      </tr>
+      <tr>
+        <td>Statut (juil. 2026)</td>
+        <td>
+          Rétabli le 9 juillet 2026 en seconde lecture — la motion de rejet échoue (314 pour, 361
+          requis), un amendement exclut le chiffrement de bout en bout
+        </td>
+        <td>En négociation — 5e trilogue échoué le 29 juin</td>
+      </tr>
     </tbody>
   </table>
 </div>

--- a/src/content/sections/nl/01-menace.mdx
+++ b/src/content/sections/nl/01-menace.mdx
@@ -47,6 +47,22 @@ Voordat u van hulpmiddelen wisselt, moet u begrijp waartegen u zich beschermt. A
           <strong>Alle</strong> platforms, ook end-to-end versleutelde berichtendiensten
         </td>
       </tr>
+      <tr>
+        <td>Looptijd</td>
+        <td>
+          Tijdelijk — <strong>verlopen op 3 april 2026</strong>, hersteld op 9 juli 2026 tot 3 april
+          2028
+        </td>
+        <td>Permanent (het standpunt van de Raad schrapt de vervalclausule)</td>
+      </tr>
+      <tr>
+        <td>Status (juli 2026)</td>
+        <td>
+          Hersteld op 9 juli 2026 in tweede lezing — de verwerpingsmotie faalt (314 voor, 361
+          vereist), een amendement zondert end-to-end-versleuteling uit
+        </td>
+        <td>In onderhandeling — 5e trialoog mislukt op 29 juni</td>
+      </tr>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
> **Divulgation d'affiliation** (per CONTRIBUTING) : je suis Thibaut Mélen, CEO de SuperNovae Studio (nika.sh). Cette PR ne contient **aucun lien**, aucun ajout de domaine, aucun changement éditorial de mise en avant — uniquement les deux lignes de tableau que `migration/inventory/diff-report.md` §2 marque comme différées « being rewritten from verified sources separately ». Aucun des faits ci-dessous ne concerne un produit auquel je suis affilié.

## Ce que ça fait

Restaure les lignes **Durée** et **Statut (juil. 2026)** du tableau comparatif Chat Control 1.0 / 2.0 (`01-menace.mdx`, fr/en/nl), avec l'histoire corrigée — la claim legacy « prolongé jusqu'au 3 avril 2028 » était fausse :

| Claim | Source primaire (déjà dans `src/data/events.json`) |
|---|---|
| Sunset initial 03/08/2024, repoussé au 03/04/2026 | EUR-Lex 2021/1232 + 2024/1307 (`first-extension`) |
| Position du Conseil : suppression de la clause d'extinction (CSAR) | Avis EDPS 16/02/2026 (`council-sunset-delete`) |
| Le Parlement rejette l'extension le 26/03/2026 (228/311/92) | Communiqué PE (`ep-says-no`) |
| **La base légale expire le 3 avril 2026** | The Record (`scanning-continues`) |
| Le Conseil rétablit le texte le 02/07/2026, jusqu'au 03/04/2028, en seconde lecture | Communiqué Conseil (`council-resurrects`) |
| 09/07/2026 : motion de rejet échoue (314 pour, 361 requis), carve-out E2EE adopté | Communiqué PE (`ep-e2ee-carveout`) |
| 5e trilogue CSAR échoué le 29 juin | chronique Breyer (citée dans le dataset) |

Zéro lien ajouté dans les MDX (conforme au pattern existant : la prose narrative ne porte pas de liens, les sources vivent dans le dataset timeline, qui documente déjà chacun de ces faits).

## Vérifié en local

`pnpm lint` (0 warning) · `pnpm format` ✓ · `pnpm check` ✓ · `pnpm build` ✓ · `pnpm test` 34/34 · `pnpm test:e2e` 27 passed.
