### PR TITLE
fix(links): répare les 3 URLs mortes des cartes outils (check-links: 0 broken)

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -298,7 +298,7 @@
       },
       {
         "label": "adguard home",
-        "href": "https://adguard.com/adguard-home"
+        "href": "https://adguard.com/adguard-home.html"
       }
     ],
     "iconSlug": "pihole",
@@ -693,8 +693,8 @@
         "href": "https://jitsi.org"
       },
       {
-        "label": "element.io/element-call",
-        "href": "https://element.io/element-call"
+        "label": "github.com/element-hq/element-call",
+        "href": "https://github.com/element-hq/element-call"
       }
     ],
     "iconSlug": "jitsi",
@@ -826,11 +826,11 @@
   {
     "id": "t-synapse",
     "name": "Matrix Synapse",
-    "url": "https://element.io/server",
+    "url": "https://element.io/server-suite",
     "links": [
       {
-        "label": "element.io/server",
-        "href": "https://element.io/server"
+        "label": "element.io/server-suite",
+        "href": "https://element.io/server-suite"
       }
     ],
     "iconSlug": "matrix",


### PR DESCRIPTION
> **Divulgation d'affiliation** (per CONTRIBUTING) : Thibaut Mélen, CEO de SuperNovae Studio. Aucun des trois projets concernés (AdGuard Home, Element Call, Synapse) ne m'est affilié. Zéro domaine ajouté à l'allowlist, zéro lien vers un de mes domaines.

`node scripts/check-links.mjs` remontait 3 liens morts sur les cartes outils :

| Cassé (404) | Remplacé par | Pourquoi |
|---|---|---|
| `adguard.com/adguard-home` | `adguard.com/adguard-home.html` | l'URL que `directory.json` utilise déjà |
| `element.io/element-call` | `github.com/element-hq/element-call` | la page produit a disparu ; le dépôt est stable et `github.com` est déjà allowlisté |
| `element.io/server` | `element.io/server-suite` | l'URL que `directory.json` utilise déjà |

Après : `177 ok · 8 bot-walled · 0 broken`.

Vérifié en local : `pnpm lint` · `pnpm format` · `pnpm build` · `pnpm test` 34/34 · `node scripts/check-links.mjs`.
