### PR TITLE
fix(nl): trois corruptions grammaticales dans la copie néerlandaise

### DIFF
--- a/src/content/sections/nl/01-menace.mdx
+++ b/src/content/sections/nl/01-menace.mdx
@@ -9,11 +9,11 @@ title: 'Begrijp de dreiging'
 
 ## Begrijp de dreiging
 
-Voordat u van hulpmiddelen wisselt, moet u begrijp waartegen u zich beschermt. Anders installeert u lukraak apps en denkt u veilig te zijn terwijl dat niet zo is.
+Voordat u van hulpmiddelen wisselt, moet u begrijpen waartegen u zich beschermt. Anders installeert u lukraak apps en denkt u veilig te zijn terwijl dat niet zo is.
 
 ### Chat Control 1.0 en 2.0, in klare taal
 
-"Chat Control" is de bijnaam voor twee Europese teksten die het scannen van uw privégescans toestaan (of zouden verplichten) op zoek naar kinderporno (CSAM). Het opgegeven doel is legitiem; het gebruikte middel, het blind scannen van de communicatie van niet-verdachte personen, komt neer op massasurveillance.
+"Chat Control" is de bijnaam voor twee Europese teksten die het scannen van uw privéberichten toestaan (of zouden verplichten) op zoek naar kinderporno (CSAM). Het opgegeven doel is legitiem; het gebruikte middel, het blind scannen van de communicatie van niet-verdachte personen, komt neer op massasurveillance.
 
 <div class="tablewrap">
   <table>

--- a/src/i18n/nl.json
+++ b/src/i18n/nl.json
@@ -17,7 +17,7 @@
   "hero": {
     "stamp": "Massasurveillance · EU · 2026",
     "eyebrow": "Een veldgids voor digitale soevereiniteit",
-    "lede": "Chat Control wil uw privégescans lezen. Hier leest u hoe u stap voor stap weer controle krijgt over uw gesprekken, uw gegevens en uw hulpmiddelen, van beginner tot klokkenluider.",
+    "lede": "Chat Control wil uw privéberichten scannen. Hier leest u hoe u stap voor stap weer controle krijgt over uw gesprekken, uw gegevens en uw hulpmiddelen, van beginner tot klokkenluider.",
     "p1": "Burger",
     "p2": "Pseudoniem account",
     "p3": "Klokkenluider"


### PR DESCRIPTION
> **Divulgation d'affiliation** (per CONTRIBUTING) : Thibaut Mélen, CEO de SuperNovae Studio. Rien dans cette PR ne me concerne — 3 corrections de grammaire néerlandaise, zéro lien, zéro domaine.

Trois corruptions objectives dans la copie NL (probablement des artefacts de migration) :

- `moet u begrijp waartegen` → `moet u begrijpen waartegen` — infinitif obligatoire après le modal (`01-menace.mdx`)
- `privégescans` (mot inexistant) → `privéberichten`, deux fois :
  - le lede du hero (`nl.json`), réaligné sur le FR « veut scanner vos messages privés » / EN « wants to scan your private messages » → « wil uw privéberichten scannen »
  - la phrase d'intro de `01-menace.mdx` (« het scannen van uw privéberichten »)

Si @thomasboom veut relire, volontiers — je m'en tiens aux corrections dont le caractère fautif est objectif (modal + infinitif, mot inexistant), pas au style.

Vérifié : `pnpm lint` · `pnpm format` · `pnpm check` · `pnpm build` · `pnpm test` 34/34.
