### PR TITLE
content(directory): ajoute Delta Chat à la messagerie (fixes #8)

### DIFF
--- a/src/data/directory.json
+++ b/src/data/directory.json
@@ -46,6 +46,13 @@
     "license": "GPL-3.0"
   },
   {
+    "id": "delta-chat",
+    "category": "messagerie",
+    "name": "Delta Chat",
+    "url": "https://delta.chat",
+    "license": "GPL-3.0"
+  },
+  {
     "id": "thunderbird",
     "category": "email",
     "name": "Thunderbird",

--- a/src/data/domains-allowlist.json
+++ b/src/data/domains-allowlist.json
@@ -20,6 +20,7 @@
     "cryptpad.org",
     "csa-scientist-open-letter.org",
     "damus.io",
+    "delta.chat",
     "digital-strategy.ec.europa.eu",
     "distrochooser.de",
     "distrosea.com",

--- a/src/i18n/content/en/directory.json
+++ b/src/i18n/content/en/directory.json
@@ -1,203 +1,71 @@
 {
-  "signal": {
-    "body": "Replaces WhatsApp. E2EE by default, non-profit foundation."
-  },
-  "simplex-chat": {
-    "body": "No identifier at all: even servers can’t know who talks to whom."
-  },
-  "session": {
-    "body": "No phone number, onion routing."
-  },
-  "element-matrix": {
-    "body": "Replaces Discord/Slack. Federated, self-hostable."
-  },
-  "briar": {
-    "body": "P2P with no internet (Bluetooth/Tor): protests, blackouts."
-  },
-  "molly": {
-    "body": "Hardened Signal for Android (fully FOSS variant)."
-  },
+  "signal": { "body": "Replaces WhatsApp. E2EE by default, non-profit foundation." },
+  "simplex-chat": { "body": "No identifier at all: even servers can’t know who talks to whom." },
+  "session": { "body": "No phone number, onion routing." },
+  "element-matrix": { "body": "Replaces Discord/Slack. Federated, self-hostable." },
+  "briar": { "body": "P2P with no internet (Bluetooth/Tor): protests, blackouts." },
+  "molly": { "body": "Hardened Signal for Android (fully FOSS variant)." },
   "delta-chat": {
     "body": "Chat over e-mail: any address works, no dedicated server, Autocrypt encryption."
   },
-  "thunderbird": {
-    "body": "The reference free mail client, OpenPGP built in."
-  },
-  "proton-mail": {
-    "body": "Open-source apps of the Swiss encrypted service."
-  },
-  "tuta": {
-    "body": "Free apps, post-quantum encryption, EU jurisdiction."
-  },
-  "firefox": {
-    "body": "Replaces Chrome. The independent engine."
-  },
-  "tor-browser": {
-    "body": "Network anonymity, anti-fingerprinting."
-  },
-  "mullvad-browser": {
-    "body": "The Tor Project’s browser, without the Tor network."
-  },
-  "brave": {
-    "body": "Chromium that blocks ads and trackers by default."
-  },
-  "ublock-origin": {
-    "body": "THE ad and tracker blocker."
-  },
-  "searxng": {
-    "body": "Self-hostable metasearch engine."
-  },
-  "wireguard": {
-    "body": "The modern VPN protocol everyone builds on."
-  },
-  "mullvad-vpn": {
-    "body": "Client of the no-account VPN (cash/Monero accepted)."
-  },
-  "proton-vpn": {
-    "body": "Free clients, honest free tier."
-  },
-  "tor": {
-    "body": "The network that separates who you are from what you do."
-  },
-  "tailscale": {
-    "body": "Private WireGuard network between your devices."
-  },
-  "headscale": {
-    "body": "The Tailscale coordination server, on your hardware."
-  },
-  "pi-hole": {
-    "body": "Blocks ads and trackers for the whole network."
-  },
-  "adguard-home": {
-    "body": "Pi-hole alternative with a modern UI."
-  },
-  "bitwarden": {
-    "body": "Cross-platform password manager."
-  },
-  "vaultwarden": {
-    "body": "Lightweight self-hosted Bitwarden server."
-  },
-  "keepassxc": {
-    "body": "100% local vault, zero cloud."
-  },
-  "aegis": {
-    "body": "2FA codes (TOTP) in a local encrypted vault (Android)."
-  },
-  "ente-auth": {
-    "body": "2FA with end-to-end encrypted sync."
-  },
-  "nextcloud": {
-    "body": "Replaces the whole Google suite, at home."
-  },
-  "cryptomator": {
-    "body": "Encrypts your files BEFORE any cloud."
-  },
-  "syncthing": {
-    "body": "Device-to-device sync, no server."
-  },
-  "restic": {
-    "body": "Encrypted, deduplicated, automatic backups."
-  },
-  "immich": {
-    "body": "Self-hosted Google Photos (faces, search)."
-  },
-  "ente-photos": {
-    "body": "E2EE photos, on-device recognition."
-  },
-  "libreoffice": {
-    "body": "The free office suite."
-  },
-  "onlyoffice": {
-    "body": "Self-hostable collaborative office."
-  },
-  "joplin": {
-    "body": "Markdown notes, optional encryption and sync."
-  },
-  "standard-notes": {
-    "body": "Notes encrypted by default."
-  },
-  "cryptpad": {
-    "body": "Collaborative Google Docs, fully encrypted."
-  },
-  "organic-maps": {
-    "body": "Offline maps with zero tracking (OpenStreetMap)."
-  },
-  "osmand": {
-    "body": "Power-user maps (hiking, contour lines)."
-  },
-  "jitsi-meet": {
-    "body": "Video calls with no account, self-hostable."
-  },
-  "mastodon": {
-    "body": "Replaces X/Twitter. Federated, no imposed algorithm."
-  },
-  "pixelfed": {
-    "body": "The fediverse’s Instagram."
-  },
-  "peertube": {
-    "body": "Federated YouTube."
-  },
-  "lemmy": {
-    "body": "Federated Reddit."
-  },
-  "damus": {
-    "body": "Nostr client: your identity is a key pair."
-  },
-  "ollama": {
-    "body": "Run LLMs locally, one command."
-  },
-  "llama-cpp": {
-    "body": "The local inference engine that made it all possible."
-  },
-  "jan": {
-    "body": "100% local ChatGPT-like, simple UI."
-  },
-  "gpt4all": {
-    "body": "Privacy-minded local LLMs, CPU-friendly."
-  },
-  "grapheneos": {
-    "body": "De-Googled, hardened Android (Pixel)."
-  },
-  "tails": {
-    "body": "Amnesic USB OS, everything through Tor."
-  },
-  "qubes-os": {
-    "body": "Compartmentalisation via sealed VMs."
-  },
-  "f-droid": {
-    "body": "The 100% free app store."
-  },
-  "postmarketos": {
-    "body": "Linux on abandoned phones."
-  },
-  "yunohost": {
-    "body": "Turnkey personal server (email included)."
-  },
-  "startos": {
-    "body": "Sovereign server, Tor by default."
-  },
-  "synapse": {
-    "body": "Your federated chat server."
-  },
-  "bitcoin-core": {
-    "body": "Money you hold yourself."
-  },
-  "monero": {
-    "body": "Private transactions by default."
-  },
-  "securedrop": {
-    "body": "Anonymous document drop for newsrooms."
-  },
-  "onionshare": {
-    "body": "Share files over Tor, no middleman."
-  },
-  "rayhunter": {
-    "body": "IMSI-catcher detector."
-  },
-  "mat2": {
-    "body": "Strips metadata before publishing."
-  },
-  "exiftool": {
-    "body": "Read and erase EXIF metadata."
-  }
+  "thunderbird": { "body": "The reference free mail client, OpenPGP built in." },
+  "proton-mail": { "body": "Open-source apps of the Swiss encrypted service." },
+  "tuta": { "body": "Free apps, post-quantum encryption, EU jurisdiction." },
+  "firefox": { "body": "Replaces Chrome. The independent engine." },
+  "tor-browser": { "body": "Network anonymity, anti-fingerprinting." },
+  "mullvad-browser": { "body": "The Tor Project’s browser, without the Tor network." },
+  "brave": { "body": "Chromium that blocks ads and trackers by default." },
+  "ublock-origin": { "body": "THE ad and tracker blocker." },
+  "searxng": { "body": "Self-hostable metasearch engine." },
+  "wireguard": { "body": "The modern VPN protocol everyone builds on." },
+  "mullvad-vpn": { "body": "Client of the no-account VPN (cash/Monero accepted)." },
+  "proton-vpn": { "body": "Free clients, honest free tier." },
+  "tor": { "body": "The network that separates who you are from what you do." },
+  "tailscale": { "body": "Private WireGuard network between your devices." },
+  "headscale": { "body": "The Tailscale coordination server, on your hardware." },
+  "pi-hole": { "body": "Blocks ads and trackers for the whole network." },
+  "adguard-home": { "body": "Pi-hole alternative with a modern UI." },
+  "bitwarden": { "body": "Cross-platform password manager." },
+  "vaultwarden": { "body": "Lightweight self-hosted Bitwarden server." },
+  "keepassxc": { "body": "100% local vault, zero cloud." },
+  "aegis": { "body": "2FA codes (TOTP) in a local encrypted vault (Android)." },
+  "ente-auth": { "body": "2FA with end-to-end encrypted sync." },
+  "nextcloud": { "body": "Replaces the whole Google suite, at home." },
+  "cryptomator": { "body": "Encrypts your files BEFORE any cloud." },
+  "syncthing": { "body": "Device-to-device sync, no server." },
+  "restic": { "body": "Encrypted, deduplicated, automatic backups." },
+  "immich": { "body": "Self-hosted Google Photos (faces, search)." },
+  "ente-photos": { "body": "E2EE photos, on-device recognition." },
+  "libreoffice": { "body": "The free office suite." },
+  "onlyoffice": { "body": "Self-hostable collaborative office." },
+  "joplin": { "body": "Markdown notes, optional encryption and sync." },
+  "standard-notes": { "body": "Notes encrypted by default." },
+  "cryptpad": { "body": "Collaborative Google Docs, fully encrypted." },
+  "organic-maps": { "body": "Offline maps with zero tracking (OpenStreetMap)." },
+  "osmand": { "body": "Power-user maps (hiking, contour lines)." },
+  "jitsi-meet": { "body": "Video calls with no account, self-hostable." },
+  "mastodon": { "body": "Replaces X/Twitter. Federated, no imposed algorithm." },
+  "pixelfed": { "body": "The fediverse’s Instagram." },
+  "peertube": { "body": "Federated YouTube." },
+  "lemmy": { "body": "Federated Reddit." },
+  "damus": { "body": "Nostr client: your identity is a key pair." },
+  "ollama": { "body": "Run LLMs locally, one command." },
+  "llama-cpp": { "body": "The local inference engine that made it all possible." },
+  "jan": { "body": "100% local ChatGPT-like, simple UI." },
+  "gpt4all": { "body": "Privacy-minded local LLMs, CPU-friendly." },
+  "grapheneos": { "body": "De-Googled, hardened Android (Pixel)." },
+  "tails": { "body": "Amnesic USB OS, everything through Tor." },
+  "qubes-os": { "body": "Compartmentalisation via sealed VMs." },
+  "f-droid": { "body": "The 100% free app store." },
+  "postmarketos": { "body": "Linux on abandoned phones." },
+  "yunohost": { "body": "Turnkey personal server (email included)." },
+  "startos": { "body": "Sovereign server, Tor by default." },
+  "synapse": { "body": "Your federated chat server." },
+  "bitcoin-core": { "body": "Money you hold yourself." },
+  "monero": { "body": "Private transactions by default." },
+  "securedrop": { "body": "Anonymous document drop for newsrooms." },
+  "onionshare": { "body": "Share files over Tor, no middleman." },
+  "rayhunter": { "body": "IMSI-catcher detector." },
+  "mat2": { "body": "Strips metadata before publishing." },
+  "exiftool": { "body": "Read and erase EXIF metadata." }
 }

--- a/src/i18n/content/en/directory.json
+++ b/src/i18n/content/en/directory.json
@@ -1,68 +1,203 @@
 {
-  "signal": { "body": "Replaces WhatsApp. E2EE by default, non-profit foundation." },
-  "simplex-chat": { "body": "No identifier at all: even servers can’t know who talks to whom." },
-  "session": { "body": "No phone number, onion routing." },
-  "element-matrix": { "body": "Replaces Discord/Slack. Federated, self-hostable." },
-  "briar": { "body": "P2P with no internet (Bluetooth/Tor): protests, blackouts." },
-  "molly": { "body": "Hardened Signal for Android (fully FOSS variant)." },
-  "thunderbird": { "body": "The reference free mail client, OpenPGP built in." },
-  "proton-mail": { "body": "Open-source apps of the Swiss encrypted service." },
-  "tuta": { "body": "Free apps, post-quantum encryption, EU jurisdiction." },
-  "firefox": { "body": "Replaces Chrome. The independent engine." },
-  "tor-browser": { "body": "Network anonymity, anti-fingerprinting." },
-  "mullvad-browser": { "body": "The Tor Project’s browser, without the Tor network." },
-  "brave": { "body": "Chromium that blocks ads and trackers by default." },
-  "ublock-origin": { "body": "THE ad and tracker blocker." },
-  "searxng": { "body": "Self-hostable metasearch engine." },
-  "wireguard": { "body": "The modern VPN protocol everyone builds on." },
-  "mullvad-vpn": { "body": "Client of the no-account VPN (cash/Monero accepted)." },
-  "proton-vpn": { "body": "Free clients, honest free tier." },
-  "tor": { "body": "The network that separates who you are from what you do." },
-  "tailscale": { "body": "Private WireGuard network between your devices." },
-  "headscale": { "body": "The Tailscale coordination server, on your hardware." },
-  "pi-hole": { "body": "Blocks ads and trackers for the whole network." },
-  "adguard-home": { "body": "Pi-hole alternative with a modern UI." },
-  "bitwarden": { "body": "Cross-platform password manager." },
-  "vaultwarden": { "body": "Lightweight self-hosted Bitwarden server." },
-  "keepassxc": { "body": "100% local vault, zero cloud." },
-  "aegis": { "body": "2FA codes (TOTP) in a local encrypted vault (Android)." },
-  "ente-auth": { "body": "2FA with end-to-end encrypted sync." },
-  "nextcloud": { "body": "Replaces the whole Google suite, at home." },
-  "cryptomator": { "body": "Encrypts your files BEFORE any cloud." },
-  "syncthing": { "body": "Device-to-device sync, no server." },
-  "restic": { "body": "Encrypted, deduplicated, automatic backups." },
-  "immich": { "body": "Self-hosted Google Photos (faces, search)." },
-  "ente-photos": { "body": "E2EE photos, on-device recognition." },
-  "libreoffice": { "body": "The free office suite." },
-  "onlyoffice": { "body": "Self-hostable collaborative office." },
-  "joplin": { "body": "Markdown notes, optional encryption and sync." },
-  "standard-notes": { "body": "Notes encrypted by default." },
-  "cryptpad": { "body": "Collaborative Google Docs, fully encrypted." },
-  "organic-maps": { "body": "Offline maps with zero tracking (OpenStreetMap)." },
-  "osmand": { "body": "Power-user maps (hiking, contour lines)." },
-  "jitsi-meet": { "body": "Video calls with no account, self-hostable." },
-  "mastodon": { "body": "Replaces X/Twitter. Federated, no imposed algorithm." },
-  "pixelfed": { "body": "The fediverse’s Instagram." },
-  "peertube": { "body": "Federated YouTube." },
-  "lemmy": { "body": "Federated Reddit." },
-  "damus": { "body": "Nostr client: your identity is a key pair." },
-  "ollama": { "body": "Run LLMs locally, one command." },
-  "llama-cpp": { "body": "The local inference engine that made it all possible." },
-  "jan": { "body": "100% local ChatGPT-like, simple UI." },
-  "gpt4all": { "body": "Privacy-minded local LLMs, CPU-friendly." },
-  "grapheneos": { "body": "De-Googled, hardened Android (Pixel)." },
-  "tails": { "body": "Amnesic USB OS, everything through Tor." },
-  "qubes-os": { "body": "Compartmentalisation via sealed VMs." },
-  "f-droid": { "body": "The 100% free app store." },
-  "postmarketos": { "body": "Linux on abandoned phones." },
-  "yunohost": { "body": "Turnkey personal server (email included)." },
-  "startos": { "body": "Sovereign server, Tor by default." },
-  "synapse": { "body": "Your federated chat server." },
-  "bitcoin-core": { "body": "Money you hold yourself." },
-  "monero": { "body": "Private transactions by default." },
-  "securedrop": { "body": "Anonymous document drop for newsrooms." },
-  "onionshare": { "body": "Share files over Tor, no middleman." },
-  "rayhunter": { "body": "IMSI-catcher detector." },
-  "mat2": { "body": "Strips metadata before publishing." },
-  "exiftool": { "body": "Read and erase EXIF metadata." }
+  "signal": {
+    "body": "Replaces WhatsApp. E2EE by default, non-profit foundation."
+  },
+  "simplex-chat": {
+    "body": "No identifier at all: even servers can’t know who talks to whom."
+  },
+  "session": {
+    "body": "No phone number, onion routing."
+  },
+  "element-matrix": {
+    "body": "Replaces Discord/Slack. Federated, self-hostable."
+  },
+  "briar": {
+    "body": "P2P with no internet (Bluetooth/Tor): protests, blackouts."
+  },
+  "molly": {
+    "body": "Hardened Signal for Android (fully FOSS variant)."
+  },
+  "delta-chat": {
+    "body": "Chat over e-mail: any address works, no dedicated server, Autocrypt encryption."
+  },
+  "thunderbird": {
+    "body": "The reference free mail client, OpenPGP built in."
+  },
+  "proton-mail": {
+    "body": "Open-source apps of the Swiss encrypted service."
+  },
+  "tuta": {
+    "body": "Free apps, post-quantum encryption, EU jurisdiction."
+  },
+  "firefox": {
+    "body": "Replaces Chrome. The independent engine."
+  },
+  "tor-browser": {
+    "body": "Network anonymity, anti-fingerprinting."
+  },
+  "mullvad-browser": {
+    "body": "The Tor Project’s browser, without the Tor network."
+  },
+  "brave": {
+    "body": "Chromium that blocks ads and trackers by default."
+  },
+  "ublock-origin": {
+    "body": "THE ad and tracker blocker."
+  },
+  "searxng": {
+    "body": "Self-hostable metasearch engine."
+  },
+  "wireguard": {
+    "body": "The modern VPN protocol everyone builds on."
+  },
+  "mullvad-vpn": {
+    "body": "Client of the no-account VPN (cash/Monero accepted)."
+  },
+  "proton-vpn": {
+    "body": "Free clients, honest free tier."
+  },
+  "tor": {
+    "body": "The network that separates who you are from what you do."
+  },
+  "tailscale": {
+    "body": "Private WireGuard network between your devices."
+  },
+  "headscale": {
+    "body": "The Tailscale coordination server, on your hardware."
+  },
+  "pi-hole": {
+    "body": "Blocks ads and trackers for the whole network."
+  },
+  "adguard-home": {
+    "body": "Pi-hole alternative with a modern UI."
+  },
+  "bitwarden": {
+    "body": "Cross-platform password manager."
+  },
+  "vaultwarden": {
+    "body": "Lightweight self-hosted Bitwarden server."
+  },
+  "keepassxc": {
+    "body": "100% local vault, zero cloud."
+  },
+  "aegis": {
+    "body": "2FA codes (TOTP) in a local encrypted vault (Android)."
+  },
+  "ente-auth": {
+    "body": "2FA with end-to-end encrypted sync."
+  },
+  "nextcloud": {
+    "body": "Replaces the whole Google suite, at home."
+  },
+  "cryptomator": {
+    "body": "Encrypts your files BEFORE any cloud."
+  },
+  "syncthing": {
+    "body": "Device-to-device sync, no server."
+  },
+  "restic": {
+    "body": "Encrypted, deduplicated, automatic backups."
+  },
+  "immich": {
+    "body": "Self-hosted Google Photos (faces, search)."
+  },
+  "ente-photos": {
+    "body": "E2EE photos, on-device recognition."
+  },
+  "libreoffice": {
+    "body": "The free office suite."
+  },
+  "onlyoffice": {
+    "body": "Self-hostable collaborative office."
+  },
+  "joplin": {
+    "body": "Markdown notes, optional encryption and sync."
+  },
+  "standard-notes": {
+    "body": "Notes encrypted by default."
+  },
+  "cryptpad": {
+    "body": "Collaborative Google Docs, fully encrypted."
+  },
+  "organic-maps": {
+    "body": "Offline maps with zero tracking (OpenStreetMap)."
+  },
+  "osmand": {
+    "body": "Power-user maps (hiking, contour lines)."
+  },
+  "jitsi-meet": {
+    "body": "Video calls with no account, self-hostable."
+  },
+  "mastodon": {
+    "body": "Replaces X/Twitter. Federated, no imposed algorithm."
+  },
+  "pixelfed": {
+    "body": "The fediverse’s Instagram."
+  },
+  "peertube": {
+    "body": "Federated YouTube."
+  },
+  "lemmy": {
+    "body": "Federated Reddit."
+  },
+  "damus": {
+    "body": "Nostr client: your identity is a key pair."
+  },
+  "ollama": {
+    "body": "Run LLMs locally, one command."
+  },
+  "llama-cpp": {
+    "body": "The local inference engine that made it all possible."
+  },
+  "jan": {
+    "body": "100% local ChatGPT-like, simple UI."
+  },
+  "gpt4all": {
+    "body": "Privacy-minded local LLMs, CPU-friendly."
+  },
+  "grapheneos": {
+    "body": "De-Googled, hardened Android (Pixel)."
+  },
+  "tails": {
+    "body": "Amnesic USB OS, everything through Tor."
+  },
+  "qubes-os": {
+    "body": "Compartmentalisation via sealed VMs."
+  },
+  "f-droid": {
+    "body": "The 100% free app store."
+  },
+  "postmarketos": {
+    "body": "Linux on abandoned phones."
+  },
+  "yunohost": {
+    "body": "Turnkey personal server (email included)."
+  },
+  "startos": {
+    "body": "Sovereign server, Tor by default."
+  },
+  "synapse": {
+    "body": "Your federated chat server."
+  },
+  "bitcoin-core": {
+    "body": "Money you hold yourself."
+  },
+  "monero": {
+    "body": "Private transactions by default."
+  },
+  "securedrop": {
+    "body": "Anonymous document drop for newsrooms."
+  },
+  "onionshare": {
+    "body": "Share files over Tor, no middleman."
+  },
+  "rayhunter": {
+    "body": "IMSI-catcher detector."
+  },
+  "mat2": {
+    "body": "Strips metadata before publishing."
+  },
+  "exiftool": {
+    "body": "Read and erase EXIF metadata."
+  }
 }

--- a/src/i18n/content/fr/directory.json
+++ b/src/i18n/content/fr/directory.json
@@ -1,203 +1,73 @@
 {
-  "signal": {
-    "body": "Remplace WhatsApp. E2EE par défaut, fondation à but non lucratif."
-  },
+  "signal": { "body": "Remplace WhatsApp. E2EE par défaut, fondation à but non lucratif." },
   "simplex-chat": {
     "body": "Sans aucun identifiant : même les serveurs ignorent qui parle à qui."
   },
-  "session": {
-    "body": "Sans numéro, routage en oignon."
-  },
-  "element-matrix": {
-    "body": "Remplace Discord/Slack. Fédéré, auto-hébergeable."
-  },
-  "briar": {
-    "body": "P2P sans internet (Bluetooth/Tor) : manifestations, blackout."
-  },
-  "molly": {
-    "body": "Signal durci pour Android (variante 100 % FOSS)."
-  },
+  "session": { "body": "Sans numéro, routage en oignon." },
+  "element-matrix": { "body": "Remplace Discord/Slack. Fédéré, auto-hébergeable." },
+  "briar": { "body": "P2P sans internet (Bluetooth/Tor) : manifestations, blackout." },
+  "molly": { "body": "Signal durci pour Android (variante 100 % FOSS)." },
   "delta-chat": {
     "body": "Chat par e-mail : n'importe quelle adresse, aucun serveur dédié, chiffrement Autocrypt."
   },
-  "thunderbird": {
-    "body": "Le client mail libre de référence, OpenPGP intégré."
-  },
-  "proton-mail": {
-    "body": "Applications open source du service chiffré suisse."
-  },
-  "tuta": {
-    "body": "Applications libres, chiffrement post-quantique, juridiction UE."
-  },
-  "firefox": {
-    "body": "Remplace Chrome. Le moteur indépendant."
-  },
-  "tor-browser": {
-    "body": "Anonymat réseau, anti-empreinte."
-  },
-  "mullvad-browser": {
-    "body": "Le navigateur du Tor Project, sans le réseau Tor."
-  },
-  "brave": {
-    "body": "Chromium qui bloque pubs et traqueurs par défaut."
-  },
-  "ublock-origin": {
-    "body": "LE bloqueur de pubs et traqueurs."
-  },
-  "searxng": {
-    "body": "Métamoteur de recherche auto-hébergeable."
-  },
-  "wireguard": {
-    "body": "Le protocole VPN moderne que tout le monde utilise."
-  },
-  "mullvad-vpn": {
-    "body": "Client du VPN sans compte (cash/Monero acceptés)."
-  },
-  "proton-vpn": {
-    "body": "Clients libres, offre gratuite honnête."
-  },
-  "tor": {
-    "body": "Le réseau qui sépare qui vous êtes de ce que vous faites."
-  },
-  "tailscale": {
-    "body": "Réseau privé WireGuard entre vos appareils."
-  },
-  "headscale": {
-    "body": "Le serveur de coordination Tailscale, chez vous."
-  },
-  "pi-hole": {
-    "body": "Bloque pubs et traqueurs pour tout le réseau."
-  },
-  "adguard-home": {
-    "body": "Alternative à Pi-hole, interface moderne."
-  },
-  "bitwarden": {
-    "body": "Gestionnaire de mots de passe multiplateforme."
-  },
-  "vaultwarden": {
-    "body": "Serveur Bitwarden léger à auto-héberger."
-  },
-  "keepassxc": {
-    "body": "Coffre 100 % local, zéro cloud."
-  },
-  "aegis": {
-    "body": "Codes 2FA (TOTP) en coffre chiffré local (Android)."
-  },
-  "ente-auth": {
-    "body": "2FA avec synchronisation chiffrée de bout en bout."
-  },
-  "nextcloud": {
-    "body": "Remplace toute la suite Google, chez vous."
-  },
-  "cryptomator": {
-    "body": "Chiffre vos fichiers AVANT tout cloud."
-  },
-  "syncthing": {
-    "body": "Synchronisation d’appareil à appareil, sans serveur."
-  },
-  "restic": {
-    "body": "Sauvegardes chiffrées, dédupliquées, automatiques."
-  },
-  "immich": {
-    "body": "Google Photos auto-hébergé (visages, recherche)."
-  },
-  "ente-photos": {
-    "body": "Photos E2EE, reconnaissance sur l’appareil."
-  },
-  "libreoffice": {
-    "body": "La suite bureautique libre."
-  },
-  "onlyoffice": {
-    "body": "Bureautique collaborative auto-hébergeable."
-  },
-  "joplin": {
-    "body": "Notes Markdown, chiffrement et sync au choix."
-  },
-  "standard-notes": {
-    "body": "Notes chiffrées par défaut."
-  },
-  "cryptpad": {
-    "body": "Google Docs collaboratif, entièrement chiffré."
-  },
-  "organic-maps": {
-    "body": "Cartes hors-ligne sans traçage (OpenStreetMap)."
-  },
-  "osmand": {
-    "body": "Cartes avancées (rando, courbes de niveau)."
-  },
-  "jitsi-meet": {
-    "body": "Visio sans compte, auto-hébergeable."
-  },
-  "mastodon": {
-    "body": "Remplace X/Twitter. Fédéré, sans algorithme imposé."
-  },
-  "pixelfed": {
-    "body": "L’Instagram du fédiverse."
-  },
-  "peertube": {
-    "body": "Le YouTube fédéré."
-  },
-  "lemmy": {
-    "body": "Le Reddit fédéré."
-  },
-  "damus": {
-    "body": "Client Nostr : votre identité est une paire de clés."
-  },
-  "ollama": {
-    "body": "Faire tourner des LLM en local, en une commande."
-  },
-  "llama-cpp": {
-    "body": "Le moteur d’inférence local qui a tout rendu possible."
-  },
-  "jan": {
-    "body": "ChatGPT-like 100 % local, interface simple."
-  },
-  "gpt4all": {
-    "body": "LLM locaux orientés vie privée, sur CPU."
-  },
-  "grapheneos": {
-    "body": "Android dégooglisé et durci (Pixel)."
-  },
-  "tails": {
-    "body": "OS amnésique sur clé USB, tout via Tor."
-  },
-  "qubes-os": {
-    "body": "Cloisonnement par machines virtuelles étanches."
-  },
-  "f-droid": {
-    "body": "Le magasin d’applications 100 % libres."
-  },
-  "postmarketos": {
-    "body": "Linux sur les téléphones abandonnés."
-  },
-  "yunohost": {
-    "body": "Serveur personnel clé en main (mail inclus)."
-  },
-  "startos": {
-    "body": "Serveur souverain, Tor par défaut."
-  },
-  "synapse": {
-    "body": "Votre serveur de messagerie fédéré."
-  },
-  "bitcoin-core": {
-    "body": "La monnaie qu’on détient soi-même."
-  },
-  "monero": {
-    "body": "Transactions confidentielles par défaut."
-  },
-  "securedrop": {
-    "body": "Dépôt anonyme de documents pour les rédactions."
-  },
-  "onionshare": {
-    "body": "Partager des fichiers via Tor, sans intermédiaire."
-  },
-  "rayhunter": {
-    "body": "Détecteur d’IMSI-catchers."
-  },
-  "mat2": {
-    "body": "Nettoie les métadonnées avant publication."
-  },
-  "exiftool": {
-    "body": "Lire et effacer les métadonnées EXIF."
-  }
+  "thunderbird": { "body": "Le client mail libre de référence, OpenPGP intégré." },
+  "proton-mail": { "body": "Applications open source du service chiffré suisse." },
+  "tuta": { "body": "Applications libres, chiffrement post-quantique, juridiction UE." },
+  "firefox": { "body": "Remplace Chrome. Le moteur indépendant." },
+  "tor-browser": { "body": "Anonymat réseau, anti-empreinte." },
+  "mullvad-browser": { "body": "Le navigateur du Tor Project, sans le réseau Tor." },
+  "brave": { "body": "Chromium qui bloque pubs et traqueurs par défaut." },
+  "ublock-origin": { "body": "LE bloqueur de pubs et traqueurs." },
+  "searxng": { "body": "Métamoteur de recherche auto-hébergeable." },
+  "wireguard": { "body": "Le protocole VPN moderne que tout le monde utilise." },
+  "mullvad-vpn": { "body": "Client du VPN sans compte (cash/Monero acceptés)." },
+  "proton-vpn": { "body": "Clients libres, offre gratuite honnête." },
+  "tor": { "body": "Le réseau qui sépare qui vous êtes de ce que vous faites." },
+  "tailscale": { "body": "Réseau privé WireGuard entre vos appareils." },
+  "headscale": { "body": "Le serveur de coordination Tailscale, chez vous." },
+  "pi-hole": { "body": "Bloque pubs et traqueurs pour tout le réseau." },
+  "adguard-home": { "body": "Alternative à Pi-hole, interface moderne." },
+  "bitwarden": { "body": "Gestionnaire de mots de passe multiplateforme." },
+  "vaultwarden": { "body": "Serveur Bitwarden léger à auto-héberger." },
+  "keepassxc": { "body": "Coffre 100 % local, zéro cloud." },
+  "aegis": { "body": "Codes 2FA (TOTP) en coffre chiffré local (Android)." },
+  "ente-auth": { "body": "2FA avec synchronisation chiffrée de bout en bout." },
+  "nextcloud": { "body": "Remplace toute la suite Google, chez vous." },
+  "cryptomator": { "body": "Chiffre vos fichiers AVANT tout cloud." },
+  "syncthing": { "body": "Synchronisation d’appareil à appareil, sans serveur." },
+  "restic": { "body": "Sauvegardes chiffrées, dédupliquées, automatiques." },
+  "immich": { "body": "Google Photos auto-hébergé (visages, recherche)." },
+  "ente-photos": { "body": "Photos E2EE, reconnaissance sur l’appareil." },
+  "libreoffice": { "body": "La suite bureautique libre." },
+  "onlyoffice": { "body": "Bureautique collaborative auto-hébergeable." },
+  "joplin": { "body": "Notes Markdown, chiffrement et sync au choix." },
+  "standard-notes": { "body": "Notes chiffrées par défaut." },
+  "cryptpad": { "body": "Google Docs collaboratif, entièrement chiffré." },
+  "organic-maps": { "body": "Cartes hors-ligne sans traçage (OpenStreetMap)." },
+  "osmand": { "body": "Cartes avancées (rando, courbes de niveau)." },
+  "jitsi-meet": { "body": "Visio sans compte, auto-hébergeable." },
+  "mastodon": { "body": "Remplace X/Twitter. Fédéré, sans algorithme imposé." },
+  "pixelfed": { "body": "L’Instagram du fédiverse." },
+  "peertube": { "body": "Le YouTube fédéré." },
+  "lemmy": { "body": "Le Reddit fédéré." },
+  "damus": { "body": "Client Nostr : votre identité est une paire de clés." },
+  "ollama": { "body": "Faire tourner des LLM en local, en une commande." },
+  "llama-cpp": { "body": "Le moteur d’inférence local qui a tout rendu possible." },
+  "jan": { "body": "ChatGPT-like 100 % local, interface simple." },
+  "gpt4all": { "body": "LLM locaux orientés vie privée, sur CPU." },
+  "grapheneos": { "body": "Android dégooglisé et durci (Pixel)." },
+  "tails": { "body": "OS amnésique sur clé USB, tout via Tor." },
+  "qubes-os": { "body": "Cloisonnement par machines virtuelles étanches." },
+  "f-droid": { "body": "Le magasin d’applications 100 % libres." },
+  "postmarketos": { "body": "Linux sur les téléphones abandonnés." },
+  "yunohost": { "body": "Serveur personnel clé en main (mail inclus)." },
+  "startos": { "body": "Serveur souverain, Tor par défaut." },
+  "synapse": { "body": "Votre serveur de messagerie fédéré." },
+  "bitcoin-core": { "body": "La monnaie qu’on détient soi-même." },
+  "monero": { "body": "Transactions confidentielles par défaut." },
+  "securedrop": { "body": "Dépôt anonyme de documents pour les rédactions." },
+  "onionshare": { "body": "Partager des fichiers via Tor, sans intermédiaire." },
+  "rayhunter": { "body": "Détecteur d’IMSI-catchers." },
+  "mat2": { "body": "Nettoie les métadonnées avant publication." },
+  "exiftool": { "body": "Lire et effacer les métadonnées EXIF." }
 }

--- a/src/i18n/content/fr/directory.json
+++ b/src/i18n/content/fr/directory.json
@@ -1,70 +1,203 @@
 {
-  "signal": { "body": "Remplace WhatsApp. E2EE par défaut, fondation à but non lucratif." },
+  "signal": {
+    "body": "Remplace WhatsApp. E2EE par défaut, fondation à but non lucratif."
+  },
   "simplex-chat": {
     "body": "Sans aucun identifiant : même les serveurs ignorent qui parle à qui."
   },
-  "session": { "body": "Sans numéro, routage en oignon." },
-  "element-matrix": { "body": "Remplace Discord/Slack. Fédéré, auto-hébergeable." },
-  "briar": { "body": "P2P sans internet (Bluetooth/Tor) : manifestations, blackout." },
-  "molly": { "body": "Signal durci pour Android (variante 100 % FOSS)." },
-  "thunderbird": { "body": "Le client mail libre de référence, OpenPGP intégré." },
-  "proton-mail": { "body": "Applications open source du service chiffré suisse." },
-  "tuta": { "body": "Applications libres, chiffrement post-quantique, juridiction UE." },
-  "firefox": { "body": "Remplace Chrome. Le moteur indépendant." },
-  "tor-browser": { "body": "Anonymat réseau, anti-empreinte." },
-  "mullvad-browser": { "body": "Le navigateur du Tor Project, sans le réseau Tor." },
-  "brave": { "body": "Chromium qui bloque pubs et traqueurs par défaut." },
-  "ublock-origin": { "body": "LE bloqueur de pubs et traqueurs." },
-  "searxng": { "body": "Métamoteur de recherche auto-hébergeable." },
-  "wireguard": { "body": "Le protocole VPN moderne que tout le monde utilise." },
-  "mullvad-vpn": { "body": "Client du VPN sans compte (cash/Monero acceptés)." },
-  "proton-vpn": { "body": "Clients libres, offre gratuite honnête." },
-  "tor": { "body": "Le réseau qui sépare qui vous êtes de ce que vous faites." },
-  "tailscale": { "body": "Réseau privé WireGuard entre vos appareils." },
-  "headscale": { "body": "Le serveur de coordination Tailscale, chez vous." },
-  "pi-hole": { "body": "Bloque pubs et traqueurs pour tout le réseau." },
-  "adguard-home": { "body": "Alternative à Pi-hole, interface moderne." },
-  "bitwarden": { "body": "Gestionnaire de mots de passe multiplateforme." },
-  "vaultwarden": { "body": "Serveur Bitwarden léger à auto-héberger." },
-  "keepassxc": { "body": "Coffre 100 % local, zéro cloud." },
-  "aegis": { "body": "Codes 2FA (TOTP) en coffre chiffré local (Android)." },
-  "ente-auth": { "body": "2FA avec synchronisation chiffrée de bout en bout." },
-  "nextcloud": { "body": "Remplace toute la suite Google, chez vous." },
-  "cryptomator": { "body": "Chiffre vos fichiers AVANT tout cloud." },
-  "syncthing": { "body": "Synchronisation d’appareil à appareil, sans serveur." },
-  "restic": { "body": "Sauvegardes chiffrées, dédupliquées, automatiques." },
-  "immich": { "body": "Google Photos auto-hébergé (visages, recherche)." },
-  "ente-photos": { "body": "Photos E2EE, reconnaissance sur l’appareil." },
-  "libreoffice": { "body": "La suite bureautique libre." },
-  "onlyoffice": { "body": "Bureautique collaborative auto-hébergeable." },
-  "joplin": { "body": "Notes Markdown, chiffrement et sync au choix." },
-  "standard-notes": { "body": "Notes chiffrées par défaut." },
-  "cryptpad": { "body": "Google Docs collaboratif, entièrement chiffré." },
-  "organic-maps": { "body": "Cartes hors-ligne sans traçage (OpenStreetMap)." },
-  "osmand": { "body": "Cartes avancées (rando, courbes de niveau)." },
-  "jitsi-meet": { "body": "Visio sans compte, auto-hébergeable." },
-  "mastodon": { "body": "Remplace X/Twitter. Fédéré, sans algorithme imposé." },
-  "pixelfed": { "body": "L’Instagram du fédiverse." },
-  "peertube": { "body": "Le YouTube fédéré." },
-  "lemmy": { "body": "Le Reddit fédéré." },
-  "damus": { "body": "Client Nostr : votre identité est une paire de clés." },
-  "ollama": { "body": "Faire tourner des LLM en local, en une commande." },
-  "llama-cpp": { "body": "Le moteur d’inférence local qui a tout rendu possible." },
-  "jan": { "body": "ChatGPT-like 100 % local, interface simple." },
-  "gpt4all": { "body": "LLM locaux orientés vie privée, sur CPU." },
-  "grapheneos": { "body": "Android dégooglisé et durci (Pixel)." },
-  "tails": { "body": "OS amnésique sur clé USB, tout via Tor." },
-  "qubes-os": { "body": "Cloisonnement par machines virtuelles étanches." },
-  "f-droid": { "body": "Le magasin d’applications 100 % libres." },
-  "postmarketos": { "body": "Linux sur les téléphones abandonnés." },
-  "yunohost": { "body": "Serveur personnel clé en main (mail inclus)." },
-  "startos": { "body": "Serveur souverain, Tor par défaut." },
-  "synapse": { "body": "Votre serveur de messagerie fédéré." },
-  "bitcoin-core": { "body": "La monnaie qu’on détient soi-même." },
-  "monero": { "body": "Transactions confidentielles par défaut." },
-  "securedrop": { "body": "Dépôt anonyme de documents pour les rédactions." },
-  "onionshare": { "body": "Partager des fichiers via Tor, sans intermédiaire." },
-  "rayhunter": { "body": "Détecteur d’IMSI-catchers." },
-  "mat2": { "body": "Nettoie les métadonnées avant publication." },
-  "exiftool": { "body": "Lire et effacer les métadonnées EXIF." }
+  "session": {
+    "body": "Sans numéro, routage en oignon."
+  },
+  "element-matrix": {
+    "body": "Remplace Discord/Slack. Fédéré, auto-hébergeable."
+  },
+  "briar": {
+    "body": "P2P sans internet (Bluetooth/Tor) : manifestations, blackout."
+  },
+  "molly": {
+    "body": "Signal durci pour Android (variante 100 % FOSS)."
+  },
+  "delta-chat": {
+    "body": "Chat par e-mail : n'importe quelle adresse, aucun serveur dédié, chiffrement Autocrypt."
+  },
+  "thunderbird": {
+    "body": "Le client mail libre de référence, OpenPGP intégré."
+  },
+  "proton-mail": {
+    "body": "Applications open source du service chiffré suisse."
+  },
+  "tuta": {
+    "body": "Applications libres, chiffrement post-quantique, juridiction UE."
+  },
+  "firefox": {
+    "body": "Remplace Chrome. Le moteur indépendant."
+  },
+  "tor-browser": {
+    "body": "Anonymat réseau, anti-empreinte."
+  },
+  "mullvad-browser": {
+    "body": "Le navigateur du Tor Project, sans le réseau Tor."
+  },
+  "brave": {
+    "body": "Chromium qui bloque pubs et traqueurs par défaut."
+  },
+  "ublock-origin": {
+    "body": "LE bloqueur de pubs et traqueurs."
+  },
+  "searxng": {
+    "body": "Métamoteur de recherche auto-hébergeable."
+  },
+  "wireguard": {
+    "body": "Le protocole VPN moderne que tout le monde utilise."
+  },
+  "mullvad-vpn": {
+    "body": "Client du VPN sans compte (cash/Monero acceptés)."
+  },
+  "proton-vpn": {
+    "body": "Clients libres, offre gratuite honnête."
+  },
+  "tor": {
+    "body": "Le réseau qui sépare qui vous êtes de ce que vous faites."
+  },
+  "tailscale": {
+    "body": "Réseau privé WireGuard entre vos appareils."
+  },
+  "headscale": {
+    "body": "Le serveur de coordination Tailscale, chez vous."
+  },
+  "pi-hole": {
+    "body": "Bloque pubs et traqueurs pour tout le réseau."
+  },
+  "adguard-home": {
+    "body": "Alternative à Pi-hole, interface moderne."
+  },
+  "bitwarden": {
+    "body": "Gestionnaire de mots de passe multiplateforme."
+  },
+  "vaultwarden": {
+    "body": "Serveur Bitwarden léger à auto-héberger."
+  },
+  "keepassxc": {
+    "body": "Coffre 100 % local, zéro cloud."
+  },
+  "aegis": {
+    "body": "Codes 2FA (TOTP) en coffre chiffré local (Android)."
+  },
+  "ente-auth": {
+    "body": "2FA avec synchronisation chiffrée de bout en bout."
+  },
+  "nextcloud": {
+    "body": "Remplace toute la suite Google, chez vous."
+  },
+  "cryptomator": {
+    "body": "Chiffre vos fichiers AVANT tout cloud."
+  },
+  "syncthing": {
+    "body": "Synchronisation d’appareil à appareil, sans serveur."
+  },
+  "restic": {
+    "body": "Sauvegardes chiffrées, dédupliquées, automatiques."
+  },
+  "immich": {
+    "body": "Google Photos auto-hébergé (visages, recherche)."
+  },
+  "ente-photos": {
+    "body": "Photos E2EE, reconnaissance sur l’appareil."
+  },
+  "libreoffice": {
+    "body": "La suite bureautique libre."
+  },
+  "onlyoffice": {
+    "body": "Bureautique collaborative auto-hébergeable."
+  },
+  "joplin": {
+    "body": "Notes Markdown, chiffrement et sync au choix."
+  },
+  "standard-notes": {
+    "body": "Notes chiffrées par défaut."
+  },
+  "cryptpad": {
+    "body": "Google Docs collaboratif, entièrement chiffré."
+  },
+  "organic-maps": {
+    "body": "Cartes hors-ligne sans traçage (OpenStreetMap)."
+  },
+  "osmand": {
+    "body": "Cartes avancées (rando, courbes de niveau)."
+  },
+  "jitsi-meet": {
+    "body": "Visio sans compte, auto-hébergeable."
+  },
+  "mastodon": {
+    "body": "Remplace X/Twitter. Fédéré, sans algorithme imposé."
+  },
+  "pixelfed": {
+    "body": "L’Instagram du fédiverse."
+  },
+  "peertube": {
+    "body": "Le YouTube fédéré."
+  },
+  "lemmy": {
+    "body": "Le Reddit fédéré."
+  },
+  "damus": {
+    "body": "Client Nostr : votre identité est une paire de clés."
+  },
+  "ollama": {
+    "body": "Faire tourner des LLM en local, en une commande."
+  },
+  "llama-cpp": {
+    "body": "Le moteur d’inférence local qui a tout rendu possible."
+  },
+  "jan": {
+    "body": "ChatGPT-like 100 % local, interface simple."
+  },
+  "gpt4all": {
+    "body": "LLM locaux orientés vie privée, sur CPU."
+  },
+  "grapheneos": {
+    "body": "Android dégooglisé et durci (Pixel)."
+  },
+  "tails": {
+    "body": "OS amnésique sur clé USB, tout via Tor."
+  },
+  "qubes-os": {
+    "body": "Cloisonnement par machines virtuelles étanches."
+  },
+  "f-droid": {
+    "body": "Le magasin d’applications 100 % libres."
+  },
+  "postmarketos": {
+    "body": "Linux sur les téléphones abandonnés."
+  },
+  "yunohost": {
+    "body": "Serveur personnel clé en main (mail inclus)."
+  },
+  "startos": {
+    "body": "Serveur souverain, Tor par défaut."
+  },
+  "synapse": {
+    "body": "Votre serveur de messagerie fédéré."
+  },
+  "bitcoin-core": {
+    "body": "La monnaie qu’on détient soi-même."
+  },
+  "monero": {
+    "body": "Transactions confidentielles par défaut."
+  },
+  "securedrop": {
+    "body": "Dépôt anonyme de documents pour les rédactions."
+  },
+  "onionshare": {
+    "body": "Partager des fichiers via Tor, sans intermédiaire."
+  },
+  "rayhunter": {
+    "body": "Détecteur d’IMSI-catchers."
+  },
+  "mat2": {
+    "body": "Nettoie les métadonnées avant publication."
+  },
+  "exiftool": {
+    "body": "Lire et effacer les métadonnées EXIF."
+  }
 }

--- a/src/i18n/content/nl/directory.json
+++ b/src/i18n/content/nl/directory.json
@@ -18,6 +18,9 @@
   "molly": {
     "body": "Geharde Signal voor Android (volledig FOSS-variant)."
   },
+  "delta-chat": {
+    "body": "Chatten via e-mail: elk adres werkt, geen aparte server, Autocrypt-versleuteling."
+  },
   "thunderbird": {
     "body": "Dé vrije referentie-mailclient, OpenPGP ingebouwd."
   },

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -133,8 +133,8 @@ describe('open-source directory', () => {
   ])
   const directory = loadDataset('directory', 'en')
 
-  it('has 66 entries: free-software license allowlist, https links', () => {
-    expect(directory).toHaveLength(66)
+  it('has 67 entries: free-software license allowlist, https links', () => {
+    expect(directory).toHaveLength(67)
     for (const e of directory) {
       expect(SPDX_ALLOWED.has(e.license), `${e.name}: license ${e.license}`).toBe(true)
       expect(e.url.startsWith('https://'), e.name).toBe(true)


### PR DESCRIPTION
> **Divulgation d'affiliation** (per CONTRIBUTING) : Thibaut Mélen, CEO de SuperNovae Studio. Aucune affiliation avec Delta Chat ni avec merlinux/Chatmail.

Répond à l'issue #8 (@jcmag). Delta Chat passe les trois règles d'admission :

1. **Traction** — ships depuis 2017, toutes plateformes, très actif (dépôt desktop poussé aujourd'hui même).
2. **Open source** — GPL-3.0, vérifié sur `deltachat/deltachat-desktop`.
3. **Privacy** — chat décentralisé par-dessus l'e-mail ordinaire : aucun serveur dédié, aucun numéro de téléphone, E2EE Autocrypt.

Le diff :
- `directory.json` : entrée `delta-chat` (messagerie, sans `iconSlug` — même fallback que briar/molly)
- descriptions fr/en/nl (une ligne chacune, style existant)
- `domains-allowlist.json` : `delta.chat` (position triée) — le diff explicite et reviewable voulu par ta politique de liens
- `content.test.ts` : pin de comptage 66 → 67

Fixes #8

Vérifié : `pnpm lint` · `pnpm format` · `pnpm check` · `pnpm build` · `pnpm test` 34/34 · `check-links` : `delta.chat` → 200 · `pnpm test:e2e` 27 passed.

(2 commits : le premier avait re-sérialisé les overlays fr/en — bruit de diff — et niché l'entrée nl au mauvais niveau, attrapé par le test de parité ; le second restaure le format compact. Diff net : +19/−2. Squash conseillé.)
