### PR TITLE
data(observatory): 6 entrées vérifiées, 15 juin → 9 juillet 2026 (UK <16 · AI Act · SCOTUS Texas · RIPOST contre-vague · euro numérique · Ofcom)

### DIFF
--- a/src/data/domains-allowlist.json
+++ b/src/data/domains-allowlist.json
@@ -107,6 +107,7 @@
     "umbrel.com",
     "values.snap.com",
     "www.amnesty.org",
+    "www.assemblee-nationale.fr",
     "www.brennancenter.org",
     "www.cnil.fr",
     "www.conseil-etat.fr",

--- a/src/data/domains-allowlist.json
+++ b/src/data/domains-allowlist.json
@@ -133,6 +133,7 @@
     "www.qubes-os.org",
     "www.reuters.com",
     "www.scmp.com",
+    "www.supremecourt.gov",
     "www.surveillancewatch.io",
     "www.techradar.com",
     "www.theguardian.com",

--- a/src/data/observatory.json
+++ b/src/data/observatory.json
@@ -418,6 +418,17 @@
     }
   },
   {
+    "id": "ripost-vsa-supprime",
+    "date": "2026-07-07",
+    "region": "fr",
+    "themes": ["aibio"],
+    "status": "rejete",
+    "src": {
+      "label": "Assemblée nationale · dossier RIPOST",
+      "href": "https://www.assemblee-nationale.fr/dyn/17/dossiers/DLR5L17N53980"
+    }
+  },
+  {
     "id": "euro-numerique-mandat",
     "date": "2026-07-09",
     "region": "eu",

--- a/src/data/observatory.json
+++ b/src/data/observatory.json
@@ -374,6 +374,17 @@
     }
   },
   {
+    "id": "ai-act-omnibus-delay",
+    "date": "2026-06-29",
+    "region": "eu",
+    "themes": ["aibio"],
+    "status": "adopte",
+    "src": {
+      "label": "Council · Omnibus VII, 29 June 2026",
+      "href": "https://www.consilium.europa.eu/en/press/press-releases/2026/06/29/artificial-intelligence-council-gives-final-green-light-to-simplify-and-streamline-rules/"
+    }
+  },
+  {
     "id": "pega-kouloglou",
     "date": "2026-07",
     "region": "eu",
@@ -382,6 +393,39 @@
     "src": {
       "label": "Citizen Lab · July 2026",
       "href": "https://citizenlab.ca/research/member-of-committee-investigating-spyware-hacked-with-pegasus/"
+    }
+  },
+  {
+    "id": "scotus-texas-app-store",
+    "date": "2026-07-06",
+    "region": "us",
+    "themes": ["identity"],
+    "status": "en_vigueur",
+    "src": {
+      "label": "SCOTUS · docket 25A1390",
+      "href": "https://www.supremecourt.gov/search.aspx?filename=/docket/docketfiles/html/public/25a1390.html"
+    }
+  },
+  {
+    "id": "euro-numerique-mandat",
+    "date": "2026-07-09",
+    "region": "eu",
+    "themes": ["money"],
+    "status": "negociation",
+    "src": {
+      "label": "European Parliament · 9 July 2026",
+      "href": "https://www.europarl.europa.eu/news/en/press-room/20260708IPR46377/digital-euro-meps-ready-to-start-negotiations"
+    }
+  },
+  {
+    "id": "ofcom-fapello",
+    "date": "2026-07-09",
+    "region": "uk",
+    "themes": ["identity"],
+    "status": "en_vigueur",
+    "src": {
+      "label": "Ofcom · 9 July 2026",
+      "href": "https://www.ofcom.org.uk/online-safety/protecting-children/ofcom-fines-porn-company-630000-for-age-check-failings"
     }
   }
 ]

--- a/src/data/observatory.json
+++ b/src/data/observatory.json
@@ -352,6 +352,17 @@
     }
   },
   {
+    "id": "uk-under16-ban",
+    "date": "2026-06-15",
+    "region": "uk",
+    "themes": ["identity", "media"],
+    "status": "propose",
+    "src": {
+      "label": "GOV.UK · DSIT, 15 June 2026",
+      "href": "https://www.gov.uk/government/news/social-media-to-be-banned-for-under-16s-in-landmark-government-move-to-givekids-their-childhood-back"
+    }
+  },
+  {
     "id": "euro-numerique-econ",
     "date": "2026-06-23",
     "region": "eu",

--- a/src/i18n/content/en/observatory.json
+++ b/src/i18n/content/en/observatory.json
@@ -151,6 +151,10 @@
     "title": "Texas: the app store checks everyone's age, and the Supreme Court lets it stand",
     "body": "The Supreme Court declines (docket 25A1390, CCIA v. Paxton) to lift the Texas App Store Accountability Act: Apple and Google must verify the age of every app-store user in Texas and require parental consent for minors, while the First Amendment challenge is litigated on the merits. Identity checks no longer guard one site's door: they guard the whole app store."
   },
+  "ripost-vsa-supprime": {
+    "title": "RIPOST: the algorithmic-CCTV extension deleted at first reading",
+    "body": "The National Assembly adopts the RIPOST public-order bill at first reading, but Article 19 — which extended the Olympics-era algorithmic video-surveillance experiment until 31 December 2030 and widened its scope — was deleted during examination, as was Article 22 (video surveillance in police custody). The rampart holds at this stage; the parliamentary shuttle continues."
+  },
   "euro-numerique-mandat": {
     "title": "Digital euro: Parliament confirms its mandate, trilogues begin",
     "body": "The plenary confirms the negotiating mandate (416 for, 169 against): trilogues with the Council open on 13 July. The mandate claims safeguards — cash protections, transaction verification without exposing personal data — and leaves the holding cap to the Commission on the ECB's recommendation. The decisive step toward traceable money is taken; the safeguards remain to be negotiated."

--- a/src/i18n/content/en/observatory.json
+++ b/src/i18n/content/en/observatory.json
@@ -127,6 +127,10 @@
     "title": "FISA 702 lapses, collection carries on anyway",
     "body": "Section 702, the warrantless collection of communications transiting US providers, was due to expire in April 2026. Two short extensions later, the authority lapses mid-June with Congress deadlocked over requiring a warrant for FBI searches of Americans. But existing certifications remain valid until March 2027: the machine runs another year on no renewed basis. A \"temporary\" surveillance power never quite switches off."
   },
+  "uk-under16-ban": {
+    "title": "UK: social media banned for under-16s",
+    "body": "The government announces a social-media ban for under-16s: Snapchat, TikTok, YouTube, Instagram, Facebook, X (messaging apps excluded), regulations laid before Christmas 2026, in force by spring 2027. To ban minors, everyone's age must be checked — “highly effective” age assurance becomes the entry condition for social media itself, no longer just for adult sites."
+  },
   "euro-numerique-econ": {
     "title": "Digital euro: \"not programmable\", yet conditional",
     "body": "Parliament’s ECON committee adopts its position (43 votes to 14, one abstention): course set for a launch by 2029. The ECB’s own FAQ swears the digital euro \"will not be programmable money\", while presenting \"conditional payments\" as optional services; under the MEPs’ position, the holding cap would be set later by the Commission on the ECB’s recommendation, reviewed every two years. The gap between the promise and the platform rests on a political decision, not a technical impossibility: the conditionality and traceability infrastructure will exist from day one."

--- a/src/i18n/content/en/observatory.json
+++ b/src/i18n/content/en/observatory.json
@@ -135,8 +135,24 @@
     "title": "Europol: budget raised to €3 billion, a mandate on encryption",
     "body": "The Commission proposes Europol’s biggest overhaul in 25 years: budget up from €1.9bn to €3bn, 900 extra staff, a mandate extended to encrypted communications, crypto-assets and AI-assisted fraud; a \"technology and innovation hub\" whose encryption work follows the ProtectEU roadmap (which schedules a Europol decryption capability by 2030); an automated \"European police data space\". ProtectEU’s armed wing: a supranational agency one MEP already warns \"must not lead to mass surveillance\"."
   },
+  "ai-act-omnibus-delay": {
+    "title": "High-risk AI: the safeguards can wait until 2027",
+    "body": "The Council seals the “Omnibus VII”: the AI Act obligations for Annex III high-risk systems — biometrics, policing, migration, employment — due to apply on 2 August 2026 are pushed back to 2 December 2027 (stand-alone systems) and 2 August 2028 (embedded ones), in the name of “simplification”. The same text bans AI-generated sexual deepfakes and CSAM — but the safeguards on surveillance AI will wait."
+  },
   "pega-kouloglou": {
     "title": "Pegasus in Parliament: the watchdog was being watched",
     "body": "Citizen Lab reveals that MEP Stelios Kouloglou, a substitute member of the PEGA committee, the very body that investigated Pegasus and spyware abuse in Europe, was hacked with Pegasus while serving on it (infections dated 21 October 2022 and 6–7 March 2023), with possible access to confidential deliberations. Citizen Lab explicitly declines to attribute the attack; a coalition of NGOs demands an EU response. Spying on the body tasked with overseeing spyware is the ultimate inversion of democratic oversight, and nobody is named responsible."
+  },
+  "scotus-texas-app-store": {
+    "title": "Texas: the app store checks everyone's age, and the Supreme Court lets it stand",
+    "body": "The Supreme Court declines (docket 25A1390, CCIA v. Paxton) to lift the Texas App Store Accountability Act: Apple and Google must verify the age of every app-store user in Texas and require parental consent for minors, while the First Amendment challenge is litigated on the merits. Identity checks no longer guard one site's door: they guard the whole app store."
+  },
+  "euro-numerique-mandat": {
+    "title": "Digital euro: Parliament confirms its mandate, trilogues begin",
+    "body": "The plenary confirms the negotiating mandate (416 for, 169 against): trilogues with the Council open on 13 July. The mandate claims safeguards — cash protections, transaction verification without exposing personal data — and leaves the holding cap to the Commission on the ECB's recommendation. The decisive step toward traceable money is taken; the safeguards remain to be negotiated."
+  },
+  "ofcom-fapello": {
+    "title": "UK: the first heavy fines for missing age checks",
+    "body": "Ofcom fines the operator of fapello.com £630,000: £600,000 for lacking the “highly effective” age assurance the Online Safety Act requires, £30,000 for ignoring a legally binding information request. The identity-check infrastructure is no longer a principle: it is now punitive, site by site."
   }
 }

--- a/src/i18n/content/fr/observatory.json
+++ b/src/i18n/content/fr/observatory.json
@@ -151,6 +151,10 @@
     "title": "Texas : l'app store vérifie l'âge de tout le monde, la Cour suprême laisse faire",
     "body": "La Cour suprême refuse (dossier 25A1390, CCIA v. Paxton) de suspendre l'App Store Accountability Act texan : Apple et Google doivent vérifier l'âge de tous les utilisateurs d'app store au Texas et exiger un consentement parental pour les mineurs, pendant que la contestation au titre du Premier amendement se plaide au fond. La vérification d'identité ne garde plus la porte d'un site : elle garde la porte du magasin d'applications tout entier."
   },
+  "ripost-vsa-supprime": {
+    "title": "RIPOST : l'extension de la VSA supprimée en première lecture",
+    "body": "L'Assemblée adopte le projet de loi RIPOST en première lecture, mais l'article 19 — qui prolongeait jusqu'au 31 décembre 2030 et élargissait l'expérimentation de la vidéoprotection algorithmique héritée des JO 2024 — a été supprimé lors de l'examen, comme l'article 22 (vidéosurveillance en garde à vue). Le rempart tient à ce stade ; la navette parlementaire continue."
+  },
   "euro-numerique-mandat": {
     "title": "Euro numérique : le Parlement confirme son mandat, trilogues lancés",
     "body": "La plénière confirme le mandat de négociation (416 pour, 169 contre) : les trilogues avec le Conseil s'ouvrent le 13 juillet. Le mandat revendique des garde-fous — protections du cash, vérification des transactions sans exposer les données personnelles — et laisse le plafond de détention à la Commission sur recommandation de la BCE. L'étape décisive vers la monnaie traçable est franchie ; les garde-fous, eux, restent à négocier."

--- a/src/i18n/content/fr/observatory.json
+++ b/src/i18n/content/fr/observatory.json
@@ -127,6 +127,10 @@
     "title": "FISA 702 expire, la collecte continue quand même",
     "body": "La Section 702, collecte sans mandat des communications transitant par les fournisseurs américains, arrivait à échéance en avril 2026. Deux extensions courtes plus tard, l’autorité expire mi-juin sans accord au Congrès, bloqué sur l’exigence d’un mandat pour les recherches du FBI visant des Américains. Mais les certifications existantes restent valides jusqu’en mars 2027 : la machine tourne un an de plus, sans base renouvelée. Un pouvoir de surveillance « temporaire » ne s’éteint jamais vraiment."
   },
+  "uk-under16-ban": {
+    "title": "Royaume-Uni : réseaux sociaux interdits aux moins de 16 ans",
+    "body": "Le gouvernement annonce l'interdiction des réseaux sociaux aux moins de 16 ans : Snapchat, TikTok, YouTube, Instagram, Facebook, X (messageries exclues), règlements déposés avant Noël 2026, entrée en vigueur au printemps 2027. Pour bannir les mineurs, il faudra vérifier l'âge de tout le monde — la vérification d'identité « hautement efficace » devient la condition d'accès au réseau social lui-même, pas seulement aux sites adultes."
+  },
   "euro-numerique-econ": {
     "title": "Euro numérique : « non programmable », mais conditionnel",
     "body": "La commission ECON du Parlement adopte sa position (43 voix contre 14, une abstention) : cap sur un lancement d’ici 2029. La FAQ de la BCE elle-même jure que l’euro numérique « ne sera pas de la monnaie programmable », tout en présentant des « paiements conditionnels » comme services optionnels ; dans la position des eurodéputés, le plafond de détention serait fixé plus tard par la Commission sur recommandation de la BCE, et révisé tous les deux ans. L’écart entre la promesse et la plateforme tient à une décision politique, pas à une impossibilité technique : l’infrastructure de conditionnalité et de traçabilité existera dès le premier jour."

--- a/src/i18n/content/fr/observatory.json
+++ b/src/i18n/content/fr/observatory.json
@@ -135,8 +135,24 @@
     "title": "Europol : budget porté à 3 milliards, mandat sur le chiffrement",
     "body": "La Commission propose la plus grande réforme d’Europol en 25 ans : budget de 1,9 à 3 milliards d’euros, 900 agents de plus, mandat étendu aux communications chiffrées, à la crypto et à la fraude assistée par IA ; un « hub technologie et innovation » dont les travaux sur le chiffrement suivent la feuille de route ProtectEU (qui programme une capacité de décryptage pour Europol d’ici 2030) ; « espace européen des données policières » à partage automatisé. Le bras armé de ProtectEU : une agence supranationale dont une eurodéputée prévient déjà qu’elle « ne doit pas mener à une surveillance de masse »."
   },
+  "ai-act-omnibus-delay": {
+    "title": "IA à haut risque : les garde-fous attendront 2027",
+    "body": "Le Conseil entérine l'« Omnibus VII » : les obligations de l'AI Act pour les systèmes à haut risque de l'annexe III — biométrie, police, migration, emploi — qui devaient s'appliquer le 2 août 2026 sont repoussées au 2 décembre 2027 (systèmes autonomes) et au 2 août 2028 (systèmes embarqués), au nom de la « simplification ». Le même texte interdit les deepfakes sexuels et le CSAM générés par IA — mais les garde-fous sur l'IA de surveillance, eux, attendront."
+  },
   "pega-kouloglou": {
     "title": "Pegasus au Parlement : le contrôleur était surveillé",
     "body": "Le Citizen Lab révèle que l’eurodéputé Stelios Kouloglou, membre suppléant de la commission PEGA (celle-là même qui enquêtait sur Pegasus et les abus de spyware en Europe), a été piraté par Pegasus pendant qu’il y siégeait (infections datées du 21 octobre 2022 et des 6-7 mars 2023), avec accès possible aux délibérations confidentielles. Le Citizen Lab décline explicitement toute attribution ; une coalition d’ONG exige une réaction de l’UE. Espionner l’organe chargé de contrôler le spyware est l’inversion ultime du contrôle démocratique, et personne n’est désigné responsable."
+  },
+  "scotus-texas-app-store": {
+    "title": "Texas : l'app store vérifie l'âge de tout le monde, la Cour suprême laisse faire",
+    "body": "La Cour suprême refuse (dossier 25A1390, CCIA v. Paxton) de suspendre l'App Store Accountability Act texan : Apple et Google doivent vérifier l'âge de tous les utilisateurs d'app store au Texas et exiger un consentement parental pour les mineurs, pendant que la contestation au titre du Premier amendement se plaide au fond. La vérification d'identité ne garde plus la porte d'un site : elle garde la porte du magasin d'applications tout entier."
+  },
+  "euro-numerique-mandat": {
+    "title": "Euro numérique : le Parlement confirme son mandat, trilogues lancés",
+    "body": "La plénière confirme le mandat de négociation (416 pour, 169 contre) : les trilogues avec le Conseil s'ouvrent le 13 juillet. Le mandat revendique des garde-fous — protections du cash, vérification des transactions sans exposer les données personnelles — et laisse le plafond de détention à la Commission sur recommandation de la BCE. L'étape décisive vers la monnaie traçable est franchie ; les garde-fous, eux, restent à négocier."
+  },
+  "ofcom-fapello": {
+    "title": "Royaume-Uni : premières grosses amendes pour absence de contrôle d'âge",
+    "body": "L'Ofcom inflige 630 000 £ à l'exploitant de fapello.com : 600 000 £ pour absence de la vérification d'âge « hautement efficace » exigée par l'Online Safety Act, 30 000 £ pour non-réponse à une demande d'information contraignante. L'infrastructure de contrôle d'identité n'est plus un principe : elle est désormais punitive, site par site."
   }
 }

--- a/src/i18n/content/nl/observatory.json
+++ b/src/i18n/content/nl/observatory.json
@@ -152,6 +152,10 @@
     "title": "Texas: de appstore controleert ieders leeftijd, en het Hooggerechtshof laat het toe",
     "body": "Het Hooggerechtshof weigert (docket 25A1390, CCIA v. Paxton) de Texaanse App Store Accountability Act te schorsen: Apple en Google moeten de leeftijd van elke appstore-gebruiker in Texas verifiëren en ouderlijke toestemming eisen voor minderjarigen, terwijl de First Amendment-zaak ten gronde wordt uitgevochten. Identiteitscontrole bewaakt niet langer de deur van één site: ze bewaakt de hele appstore."
   },
+  "ripost-vsa-supprime": {
+    "title": "RIPOST: de verlenging van algoritmische cameratoezicht geschrapt in eerste lezing",
+    "body": "De Nationale Vergadering neemt de RIPOST-wet in eerste lezing aan, maar artikel 19 — dat het experiment met algoritmisch cameratoezicht uit de Spelen van 2024 tot 31 december 2030 verlengde en verruimde — werd tijdens de behandeling geschrapt, net als artikel 22 (videobewaking in politiecellen). De borstwering houdt in dit stadium stand; de parlementaire pendel gaat verder."
+  },
   "euro-numerique-mandat": {
     "title": "Digitale euro: het Parlement bevestigt zijn mandaat, trilogen van start",
     "body": "De plenaire vergadering bevestigt het onderhandelingsmandaat (416 voor, 169 tegen): de trilogen met de Raad beginnen op 13 juli. Het mandaat claimt waarborgen — bescherming van contant geld, transactieverificatie zonder persoonsgegevens bloot te leggen — en laat het bezitplafond aan de Commissie op aanbeveling van de ECB. De beslissende stap naar traceerbaar geld is gezet; de waarborgen moeten nog worden onderhandeld."

--- a/src/i18n/content/nl/observatory.json
+++ b/src/i18n/content/nl/observatory.json
@@ -128,6 +128,10 @@
     "title": "FISA 702 verstrijkt, de dataverzameling draait gewoon door",
     "body": "Sectie 702, het zonder bevelschrift verzamelen van communicatie die via Amerikaanse providers loopt, zou in april 2026 verstrijken. Twee korte verlengingen later vervalt de bevoegdheid medio juni, met een Congres dat muurvast zit op de vraag of FBI-zoekopdrachten naar Amerikanen een bevelschrift vereisen. Maar de bestaande certificeringen blijven geldig tot maart 2027: de machine draait nog een jaar door zonder hernieuwde grondslag. Een \"tijdelijke\" surveillancebevoegdheid gaat nooit helemaal uit."
   },
+  "uk-under16-ban": {
+    "title": "VK: sociale media verboden voor jongeren onder 16",
+    "body": "De regering kondigt een socialemediaverbod voor min-16-jarigen aan: Snapchat, TikTok, YouTube, Instagram, Facebook, X (berichtenapps uitgezonderd), regelgeving vóór Kerstmis 2026, van kracht in het voorjaar van 2027. Om minderjarigen te weren moet ieders leeftijd worden gecontroleerd — “zeer doeltreffende” leeftijdsverificatie wordt de toegangsvoorwaarde voor sociale media zelf, niet langer alleen voor adult-sites."
+  },
   "euro-numerique-econ": {
     "title": "Digitale euro: \"niet programmeerbaar\", maar wel conditioneel",
     "body": "De ECON-commissie van het Parlement neemt haar standpunt aan (43 stemmen tegen 14, één onthouding): koers gezet naar een lancering tegen 2029. De eigen FAQ van de ECB bezweert dat de digitale euro \"geen programmeerbaar geld zal zijn\", terwijl ze \"conditionele betalingen\" presenteert als optionele diensten; volgens het standpunt van de europarlementariërs zou de aanhoudingslimiet later door de Commissie worden vastgesteld op aanbeveling van de ECB, om de twee jaar herzien. De kloof tussen de belofte en het platform berust op een politieke beslissing, niet op een technische onmogelijkheid: de infrastructuur voor conditionaliteit en traceerbaarheid bestaat vanaf dag één."

--- a/src/i18n/content/nl/observatory.json
+++ b/src/i18n/content/nl/observatory.json
@@ -136,8 +136,24 @@
     "title": "Europol: budget naar 3 miljard euro, een mandaat over versleuteling",
     "body": "De Commissie stelt de grootste hervorming van Europol in 25 jaar voor: budget van €1,9 mld naar €3 mld, 900 extra personeelsleden, een mandaat uitgebreid naar versleutelde communicatie, cryptoactiva en AI-ondersteunde fraude; een \"technology and innovation hub\" waarvan het versleutelingswerk de ProtectEU-routekaart volgt (die tegen 2030 een ontsleutelingscapaciteit voor Europol inplant); een geautomatiseerde \"Europese politiedataruimte\". De gewapende arm van ProtectEU: een supranationaal agentschap waarvan één europarlementariër nu al waarschuwt dat het \"niet tot massasurveillance mag leiden\"."
   },
+  "ai-act-omnibus-delay": {
+    "title": "Hoogrisico-AI: de waarborgen wachten tot 2027",
+    "body": "De Raad bezegelt de “Omnibus VII”: de AI Act-verplichtingen voor hoogrisicosystemen van bijlage III — biometrie, politie, migratie, werk — die op 2 augustus 2026 zouden gelden, schuiven op naar 2 december 2027 (op zichzelf staande systemen) en 2 augustus 2028 (ingebedde), in naam van “vereenvoudiging”. Dezelfde tekst verbiedt AI-gegenereerde seksuele deepfakes en CSAM — maar de waarborgen rond surveillance-AI wachten."
+  },
   "pega-kouloglou": {
     "title": "Pegasus in het Parlement: de waakhond werd zelf bewaakt",
     "body": "Citizen Lab onthult dat europarlementariër Stelios Kouloglou, plaatsvervangend lid van de PEGA-commissie (nota bene het orgaan dat Pegasus en spywaremisbruik in Europa onderzocht), met Pegasus werd gehackt terwijl hij er zitting in had (infecties gedateerd op 21 oktober 2022 en 6–7 maart 2023), met mogelijke toegang tot vertrouwelijke beraadslagingen. Citizen Lab weigert uitdrukkelijk de aanval te attribueren; een coalitie van ngo's eist een Europese reactie. Het orgaan bespioneren dat toezicht moet houden op spyware is de ultieme omkering van democratische controle, en niemand wordt verantwoordelijk genoemd."
+  },
+  "scotus-texas-app-store": {
+    "title": "Texas: de appstore controleert ieders leeftijd, en het Hooggerechtshof laat het toe",
+    "body": "Het Hooggerechtshof weigert (docket 25A1390, CCIA v. Paxton) de Texaanse App Store Accountability Act te schorsen: Apple en Google moeten de leeftijd van elke appstore-gebruiker in Texas verifiëren en ouderlijke toestemming eisen voor minderjarigen, terwijl de First Amendment-zaak ten gronde wordt uitgevochten. Identiteitscontrole bewaakt niet langer de deur van één site: ze bewaakt de hele appstore."
+  },
+  "euro-numerique-mandat": {
+    "title": "Digitale euro: het Parlement bevestigt zijn mandaat, trilogen van start",
+    "body": "De plenaire vergadering bevestigt het onderhandelingsmandaat (416 voor, 169 tegen): de trilogen met de Raad beginnen op 13 juli. Het mandaat claimt waarborgen — bescherming van contant geld, transactieverificatie zonder persoonsgegevens bloot te leggen — en laat het bezitplafond aan de Commissie op aanbeveling van de ECB. De beslissende stap naar traceerbaar geld is gezet; de waarborgen moeten nog worden onderhandeld."
+  },
+  "ofcom-fapello": {
+    "title": "VK: de eerste zware boetes voor ontbrekende leeftijdscontroles",
+    "body": "Ofcom legt de exploitant van fapello.com £630.000 op: £600.000 voor het ontbreken van de “zeer doeltreffende” leeftijdsverificatie die de Online Safety Act vereist, £30.000 voor het negeren van een juridisch bindend informatieverzoek. De identiteitscontrole-infrastructuur is geen principe meer: ze is nu bestraffend, site per site."
   }
 }

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -83,8 +83,8 @@ describe('precedents timeline (events)', () => {
 describe('big brother observatory', () => {
   const drift = loadDataset('observatory', 'en')
 
-  it('has 40 entries, chronologically sorted', () => {
-    expect(drift).toHaveLength(40)
+  it('has 41 entries, chronologically sorted', () => {
+    expect(drift).toHaveLength(41)
     const dates = drift.map((e) => e.date)
     expect(dates).toEqual([...dates].sort())
   })

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -83,8 +83,8 @@ describe('precedents timeline (events)', () => {
 describe('big brother observatory', () => {
   const drift = loadDataset('observatory', 'en')
 
-  it('has 35 entries, chronologically sorted', () => {
-    expect(drift).toHaveLength(35)
+  it('has 39 entries, chronologically sorted', () => {
+    expect(drift).toHaveLength(39)
     const dates = drift.map((e) => e.date)
     expect(dates).toEqual([...dates].sort())
   })

--- a/tests/unit/content.test.ts
+++ b/tests/unit/content.test.ts
@@ -83,8 +83,8 @@ describe('precedents timeline (events)', () => {
 describe('big brother observatory', () => {
   const drift = loadDataset('observatory', 'en')
 
-  it('has 39 entries, chronologically sorted', () => {
-    expect(drift).toHaveLength(39)
+  it('has 40 entries, chronologically sorted', () => {
+    expect(drift).toHaveLength(40)
     const dates = drift.map((e) => e.date)
     expect(dates).toEqual([...dates].sort())
   })


### PR DESCRIPTION
> **Divulgation d'affiliation** (per CONTRIBUTING) : Thibaut Mélen, CEO de SuperNovae Studio. Aucun lien avec les institutions ou entreprises citées. Zéro lien vers mes domaines ; deux domaines ajoutés à l'allowlist (`www.supremecourt.gov`, `www.assemblee-nationale.fr` — sources institutionnelles primaires).

Six entrées d'observatoire pour la fenêtre 15 juin → 9 juillet 2026 — dérive ET contre-vague — chaque claim **re-vérifiée à la main sur le document primaire** avant inclusion (pas seulement agrégée) :

| Entrée | Fait | Source primaire | Vérif |
|---|---|---|---|
| `uk-under16-ban` (uk · identité+média · proposé) | Le gouvernement UK annonce l'interdiction des réseaux sociaux aux <16 ans (messageries exclues) — règlements avant Noël 2026, vigueur printemps 2027 : la vérification d'âge « hautement efficace » pour tout le monde | [GOV.UK · DSIT, 15 juin](https://www.gov.uk/government/news/social-media-to-be-banned-for-under-16s-in-landmark-government-move-to-givekids-their-childhood-back) | `first-published-at 2026-06-15` + périmètre extrait de la page |
| `ai-act-omnibus-delay` (eu · aibio · adopté) | Le Conseil entérine l'Omnibus VII : obligations haut-risque annexe III (biométrie, police, migration) repoussées du 2 août 2026 au 2 déc 2027 / 2 août 2028 | [Consilium, 29 juin](https://www.consilium.europa.eu/en/press/press-releases/2026/06/29/artificial-intelligence-council-gives-final-green-light-to-simplify-and-streamline-rules/) | dates extraites de la page même (bot-wall : même classe que ton entrée Consilium existante) |
| `scotus-texas-app-store` (us · identité · en vigueur) | La Cour suprême refuse de suspendre l'App Store Accountability Act texan — vérification d'âge de TOUS les utilisateurs d'app store | [Docket 25A1390](https://www.supremecourt.gov/search.aspx?filename=/docket/docketfiles/html/public/25a1390.html) | entrée du 6 juillet lue sur le docket : « referred to the Court is denied » |
| `ripost-vsa-supprime` (fr · aibio · **rejeté** — contre-vague) | L'Assemblée adopte RIPOST en 1re lecture avec l'article 19 SUPPRIMÉ (prolongation VSA → 31 déc 2030 + élargissement) ; art. 22 (vidéosurveillance garde à vue) supprimé aussi — suite naturelle de ton entrée `fr-vsa-prolongee` | [Dossier AN DLR5L17N53980](https://www.assemblee-nationale.fr/dyn/17/dossiers/DLR5L17N53980) | marqueurs « [SUPPRIMÉ] Article 19/22 » lus sur la page du dossier même · « Texte adopté 7 juillet » — c'était mon candidat écarté hier pour périmètre mouvant, maintenant stable |
| `euro-numerique-mandat` (eu · argent · négociation) | La plénière confirme le mandat euro numérique 416/169, trilogues le 13 juillet | [Communiqué PE, 9 juillet](https://www.europarl.europa.eu/news/en/press-room/20260708IPR46377/digital-euro-meps-ready-to-start-negotiations) | chiffres 416/169 vérifiés dans la page |
| `ofcom-fapello` (uk · identité · en vigueur) | Première grosse amende OSA pour absence de contrôle d'âge : 630 000 £ (600k + 30k) contre l'exploitant de fapello.com | [Ofcom, 9 juillet](https://www.ofcom.org.uk/online-safety/protecting-children/ofcom-fines-porn-company-630000-for-age-check-failings) | `article:published_time 2026-07-09T09:02Z` + montants vérifiés |

Les corps fr/en/nl suivent le ton existant (fait daté + le basculement que ça révèle, nuances honnêtes incluses — le mandat euro numérique revendique des protections cash, l'Omnibus interdit aussi les deepfakes sexuels IA).

**Écartés volontairement** (rigueur avant volume) : les suites Chat Control post-vote (aucune étape datée solide au 10 juillet : ni JO, ni réaction Signal/Threema officielle) · Kouloglou/Pegasus (déjà couvert par ton entrée `pega-kouloglou`, même source).

Vérifié : `pnpm lint` · `pnpm format` · `pnpm check` · `pnpm build` · `pnpm test` 34/34 · `check-links` (les 2 nouvelles URLs accessibles → 200 ; Consilium bot-wallée comme l'existante, vérifiée à la main) · `pnpm test:e2e` 27 passed. Tri chronologique tenu, pin 35 → 41.


