### PR TITLE
Sécurité : ajoute l'en-tête HSTS (Strict-Transport-Security)

### DIFF
--- a/docker/security-headers.conf
+++ b/docker/security-headers.conf
@@ -8,3 +8,12 @@ add_header Referrer-Policy "no-referrer" always;
 add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), interest-cohort=()" always;
 add_header Cross-Origin-Opener-Policy "same-origin" always;
 add_header Cross-Origin-Resource-Policy "same-origin" always;
+# HSTS. TLS terminates at the platform proxy (Coolify) and this nginx serves
+# HTTP on :80; the proxy forwards the header to the browser over HTTPS, where
+# it is honored. A browser ignores HSTS received over plain HTTP, so a direct
+# HTTP hit to nginx can never lock a client out — the header is only recorded
+# on the proxy's secure connection. `includeSubDomains` assumes every
+# *.exitchatcontrol.org host is HTTPS-only. `preload` is deliberately omitted:
+# it is a months-long, one-way commitment — add it (and submit to
+# hstspreload.org) only once the max-age below has run in production unchanged.
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;


### PR DESCRIPTION
Le site centralise déjà tous ses en-têtes de sécurité côté nginx (CSP, X-Frame-Options, COOP, CORP…) plutôt que de dépendre du proxy ; HSTS y manquait. Ajouté dans le même snippet partagé.

Topologie : le TLS est terminé au proxy de la plateforme (Coolify) et ce nginx sert en HTTP sur :80 ; le proxy relaie l'en-tête au navigateur en HTTPS, où il est honoré. Un navigateur ignore un HSTS reçu en clair, donc un accès HTTP direct à nginx ne peut jamais verrouiller un client par erreur — l'en-tête n'est enregistré que sur la connexion sécurisée du proxy.

Choix conservateurs et réversibles :
- max-age=31536000 (un an), valeur standard.
- includeSubDomains : suppose que tout *.exitchatcontrol.org est en HTTPS — à retirer en revue si un sous-domaine sert encore du HTTP.
- preload volontairement omis : engagement à sens unique (des mois pour en sortir) ; à ajouter seulement après une période stable en prod.

Validé par analogie de syntaxe (même forme que les add_header voisins ; la ligne CSP du fichier porte déjà des ';' entre guillemets) ; nginx -t via Docker impossible ici (pull d'images bloqué par le proxy sortant).

